### PR TITLE
Fix for Issue #162 - NPCs Trade window showing Sell items correctly

### DIFF
--- a/modules/game_npctrade/npctrade.lua
+++ b/modules/game_npctrade/npctrade.lua
@@ -364,19 +364,23 @@ function onOpenNpcTrade(items)
   tradeItems[SELL] = {}
 
   for key,item in pairs(items) do
-    local newItem = {}
-    newItem.ptr = item[1]
-    newItem.name = item[2]
-    newItem.weight = item[3] / 100
-
+    
     if item[4] > 0 then
+      local newItem = {}
+      newItem.ptr = item[1]
+      newItem.name = item[2]
+      newItem.weight = item[3] / 100
       newItem.price = item[4]
       table.insert(tradeItems[BUY], newItem)
-    elseif item[5] > 0 then
+    end
+    
+    if item[5] > 0 then
+      local newItem = {}
+      newItem.ptr = item[1]
+      newItem.name = item[2]
+      newItem.weight = item[3] / 100
       newItem.price = item[5]
       table.insert(tradeItems[SELL], newItem)
-    else
-      error("server error: item name " .. item[2] .. " has neither buy or sell price.")
     end
   end
 


### PR DESCRIPTION
If an item had both a sell and buy price, it was only being added to the
buy list.

This issue was listed in #162, but due to language barriers was closed before the issue was conveyed.
