### PR TITLE
Animated text does not always stack vertically correctly.

### DIFF
--- a/src/client/animatedtext.cpp
+++ b/src/client/animatedtext.cpp
@@ -84,6 +84,11 @@ void AnimatedText::setText(const std::string& text)
     m_cachedText.setText(text);
 }
 
+int AnimatedText::getCalculatedVerticalOffset()
+{
+    return m_offset.y + (-48 * this->getTimer().ticksElapsed() / (float)Otc::ANIMATED_TEXT_DURATION);
+}
+
 bool AnimatedText::merge(const AnimatedTextPtr& other)
 {
     if(other->getColor() != m_color)
@@ -99,7 +104,7 @@ bool AnimatedText::merge(const AnimatedTextPtr& other)
         std::string string1 = m_cachedText.getText();
         std::string string2 = other->getCachedText().getText();
         bool p = false;
-        if(string1[0] == '+' && string2[0] == '+') {
+        if(string1.length() > 0 && string1[0] == '+' && string2.length() > 0 && string2[0] == '+') {
             p = true;
             string1.erase(0,1);
             string2.erase(0,1);

--- a/src/client/animatedtext.cpp
+++ b/src/client/animatedtext.cpp
@@ -96,10 +96,20 @@ bool AnimatedText::merge(const AnimatedTextPtr& other)
         return false;
 
     try {
-        int number = stdext::safe_cast<int>(m_cachedText.getText());
-        int otherNumber = stdext::safe_cast<int>(other->getCachedText().getText());
+        std::string string1 = m_cachedText.getText();
+        std::string string2 = other->getCachedText().getText();
+        bool p = false;
+        if(string1[0] == '+' && string2[0] == '+') {
+            p = true;
+            string1.erase(0,1);
+            string2.erase(0,1);
+        }
+        int number = stdext::safe_cast<int>(string1);
+        int otherNumber = stdext::safe_cast<int>(string2);
 
         std::string text = stdext::format("%d", number + otherNumber);
+        if(p)
+            text = "+" + text;
         m_cachedText.setText(text);
         return true;
     }

--- a/src/client/animatedtext.h
+++ b/src/client/animatedtext.h
@@ -44,6 +44,7 @@ public:
     const CachedText& getCachedText() const { return m_cachedText; }
     Point getOffset() { return m_offset; }
     Timer getTimer() { return m_animationTimer; }
+    int getCalculatedVerticalOffset();
 
     bool merge(const AnimatedTextPtr& other);
 

--- a/src/client/map.cpp
+++ b/src/client/map.cpp
@@ -120,37 +120,20 @@ void Map::addThing(const ThingPtr& thing, const Position& pos, int stackPos)
             // this code will stack animated texts of the same color
             AnimatedTextPtr animatedText = thing->static_self_cast<AnimatedText>();
             AnimatedTextPtr prevAnimatedText;
+            int offset = 12;
             bool merged = false;
             for(auto other : m_animatedTexts) {
                 if(other->getPosition() == pos) {
-                    if(!prevAnimatedText)
-                        prevAnimatedText = other;
-                    else {
-                        float pt = prevAnimatedText->getTimer().ticksElapsed();
-                        float ot = other->getTimer().ticksElapsed();
-                        Point poff = prevAnimatedText->getOffset();
-                        Point ooff = other->getOffset();
-                        poff += Point(0, 12 - 48 * pt / (float)Otc::ANIMATED_TEXT_DURATION);
-                        ooff += Point(0, 12 - 48 * ot / (float)Otc::ANIMATED_TEXT_DURATION);
-                        if(poff.y < ooff.y) // Want the one with the "lowest" screen position, which is more positive
-                            prevAnimatedText = other;
-                    }
+                    // 12 is to account for height of text
+                    // Want the one with the "lowest" screen position, which is more positive
+                    offset = std::max(offset, 12 + other->getCalculatedVerticalOffset());
 
-                    if(!merged && other->merge(animatedText)) {
+                    if(!merged && other->merge(animatedText))
                         merged = true;
-                        //break;
-                    }
                 }
             }
             if(!merged) {
-                if(prevAnimatedText) {
-                    Point offset = prevAnimatedText->getOffset();
-                    float t = prevAnimatedText->getTimer().ticksElapsed();
-                    int y = 12 - 48 * t / (float)Otc::ANIMATED_TEXT_DURATION;
-                    offset += Point(0, y);
-                    offset.y = std::max(offset.y, 12); // If text is above the starting position, use default of 12
-                    animatedText->setOffset(offset);
-                }
+                animatedText->setOffset(Point(0, offset));
                 m_animatedTexts.push_back(animatedText);
             }
         } else if(thing->isStaticText()) {


### PR DESCRIPTION
Fix for Animated text not stacking properly vertically.
Change will also merge text of the form "+123" since some servers use this for healing.

I think the style followed the code conventions properly, but it might be a little redundant on calculations, maybe they should be moved to a function inside of the Animated Text class?