### PR TITLE
Fix compiling on OS X

### DIFF
--- a/src/framework/stdext/thread.h
+++ b/src/framework/stdext/thread.h
@@ -26,7 +26,7 @@
 #include <boost/thread/future.hpp>
 
 // hack to enable std::thread on mingw32 4.6
-#if !defined(_GLIBCXX_HAS_GTHREADS) && defined(__GNUG__)
+#if !defined(_GLIBCXX_HAS_GTHREADS) && defined(__GNUG__) && !defined(__clang__)
 
 #include <boost/thread/thread.hpp>
 #include <boost/thread/mutex.hpp>


### PR DESCRIPTION
Clang on Mac OS X 10.8.4 has std::thread, using the MinGW hack generates compiling errors.
