### PR TITLE
Make tab navigation more intuitive

### DIFF
--- a/modules/corelib/ui/uimovabletabbar.lua
+++ b/modules/corelib/ui/uimovabletabbar.lua
@@ -389,10 +389,16 @@ function UIMoveableTabBar:selectNextTab()
     if #self.postTabs > 0 then
       local widget = showPostTab(self)
       self:selectTab(widget)
-      updateTabs(self)
     else
+      if #self.preTabs > 0 then
+        for i = 1, #self.preTabs do
+          showPreTab(self)
+        end
+      end
+
       self:selectTab(self.tabs[1])
     end
+    updateTabs(self)
     return
   end
 
@@ -419,10 +425,16 @@ function UIMoveableTabBar:selectPrevTab()
     if #self.preTabs > 0 then
       local widget = showPreTab(self)
       self:selectTab(widget)
-      updateTabs(self)
     else
+      if #self.postTabs > 0 then
+        for i = 1, #self.postTabs do
+          showPostTab(self)
+        end
+      end
+
       self:selectTab(self.tabs[#self.tabs])
     end
+    updateTabs(self)
     return
   end
 


### PR DESCRIPTION
This commit makes the chat (and movable tab bar) behavior more intuitive, basically when we currently have the last tab selected, and press the Tab key, it will jump to the first tab. Respectively, when we have the first tab selected and press Shift-Tab, the last tab will get selected. It is way easier to navigate through the tabs this way while playing.
