### PR TITLE
Update hotkeys behavior

### DIFF
--- a/modules/game_hotkeys/hotkeys_manager.lua
+++ b/modules/game_hotkeys/hotkeys_manager.lua
@@ -401,7 +401,18 @@ function doKeyCombo(keyCombo)
     end
   elseif hotKey.useType == HOTKEY_MANAGER_USEONTARGET then
     local attackingCreature = g_game.getAttackingCreature()
-    if not attackingCreature then return end
+    if not attackingCreature then
+      local item = Item.create(hotKey.itemId)
+      if g_game.getProtocolVersion() < 780 or hotKey.subType then
+        local tmpItem = g_game.findPlayerItem(hotKey.itemId, hotKey.subType or -1)
+        if not tmpItem then return end
+        item = tmpItem
+      end
+
+      modules.game_interface.startUseWith(item)
+      return
+    end
+
     if not attackingCreature:getTile() then return end
     if g_game.getProtocolVersion() < 780 or hotKey.subType then
       local item = g_game.findPlayerItem(hotKey.itemId, hotKey.subType or -1)


### PR DESCRIPTION
This will make the "Use on target" hot keys default to cross-hair when we do not have any target. It is easier if the hotkey works this way rather than aiming manually or setting up a separate "With crosshair" hot key for the same item. Cipsoft Client has it as well, and while I do realize that otclient is not meant to reassemble their client completely, it is still a nice feature to have.
