### PR TITLE
Fix Tile::getTopUseThing()

### DIFF
--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -399,13 +399,13 @@ ThingPtr Tile::getTopUseThing()
 
     for(uint i = 0; i < m_things.size(); ++i) {
         ThingPtr thing = m_things[i];
-        if(thing->isForceUse() || (!thing->isGround() && !thing->isGroundBorder() && !thing->isOnBottom() && !thing->isOnTop() && !thing->isCreature()))
+        if (thing->isForceUse() || (!thing->isGround() && !thing->isGroundBorder() && !thing->isOnBottom() && !thing->isOnTop() && !thing->isCreature() && !thing->isSplash()))
             return thing;
     }
 
     for(uint i = 0; i < m_things.size(); ++i) {
         ThingPtr thing = m_things[i];
-        if(!thing->isGround() && !thing->isGroundBorder() && !thing->isCreature())
+        if (!thing->isGround() && !thing->isGroundBorder() && !thing->isCreature() && !thing->isSplash())
             return thing;
     }
 


### PR DESCRIPTION
Fixing an issue which returned splash items instead of real usable items.
In case a blood splash is inside an open door, you are unable to close it. This patch will ignore splash items and return the real usable item correctly.

~~~~Lord Hepipud~~~~
