### PR TITLE
Fix compilation problem when compiling without FW_SOUND flag.

### DIFF
--- a/src/framework/core/graphicalapplication.cpp
+++ b/src/framework/core/graphicalapplication.cpp
@@ -30,10 +30,10 @@
 #include <framework/graphics/particlemanager.h>
 #include <framework/graphics/texturemanager.h>
 #include <framework/graphics/painter.h>
+#include <framework/input/mouse.h>
 
 #ifdef FW_SOUND
 #include <framework/sound/soundmanager.h>
-#include <framework/input/mouse.h>
 #endif
 
 GraphicalApplication g_app;


### PR DESCRIPTION
If you compile without the FW_SOUND flag you get an error that says "g.mouse is undefined". This should fix that.
