### PR TITLE
New Feature / Fix: Exploration mode for minimap

### DIFF
--- a/src/client/minimap.cpp
+++ b/src/client/minimap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2013 OTClient <https://github.com/edubart/otclient>
+ * Copyright (c) 2010-2014 OTClient <https://github.com/edubart/otclient>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,6 +23,7 @@
 
 #include "minimap.h"
 #include "tile.h"
+#include "game.h"
 
 #include <framework/graphics/image.h>
 #include <framework/graphics/texture.h>
@@ -96,6 +97,9 @@ void Minimap::clean()
 {
     for(int i=0;i<=Otc::MAX_Z;++i)
         m_tileBlocks[i].clear();
+
+    minimapFloorCache.clear();
+    minimapDrawCache.clear();
 }
 
 void Minimap::draw(const Rect& screenRect, const Position& mapCenter, float scale, const Color& color)
@@ -203,12 +207,96 @@ void Minimap::updateTile(const Position& pos, const TilePtr& tile)
         minimapTile.speed = std::min<int>((int)std::ceil(tile->getGroundSpeed() / 10.0f), 255);
     }
 
-    if(minimapTile != MinimapTile()) {
-        MinimapBlock& block = getBlock(pos);
-        Point offsetPos = getBlockOffset(Point(pos.x, pos.y));
-        block.updateTile(pos.x - offsetPos.x, pos.y - offsetPos.y, minimapTile);
-        block.justSaw();
-    }
+#ifndef EXPLORE_MODE
+	if (minimapTile != MinimapTile()) {
+		MinimapBlock& block = getBlock(pos);
+		Point offsetPos = getBlockOffset(Point(pos.x, pos.y));
+		block.updateTile(pos.x - offsetPos.x, pos.y - offsetPos.y, minimapTile);
+		block.justSaw();
+	}
+#else
+	/*
+	* Exploration mode:
+	* By default OTClient is drawing all tiles which are send by the server to the minimap view
+	* Some server admins might not want this and will receive a working patch for this. Simply add EXPLORE_MODE to build dependencies to make it work
+	* While still all tiles are received from the server, only the visible ones on the same floor as the player including tiles inside the view range
+	* will be drawn. All other tiles will be added to a caching system and drawn later in case the player walks up or down a floor
+	* To prevent the Client from freezing or slowing done after a long play time, the cache will be flushed of all tiles which have been drawn already
+	* or which are far out from our view range
+	*/
+
+	//First we need to get the player object
+	LocalPlayerPtr localPlayer = g_game.getLocalPlayer();
+
+	//Ensure each position is only cached once, but still check for a possible change (might happen in case we add a wall for example by script)
+	if (minimapDrawCache[pos] == minimapTile) {
+		return;
+	}
+	minimapDrawCache[pos] = minimapTile;
+
+	//Like the old system, check if there is actually a minimap tile available to draw
+	if (minimapTile != MinimapTile()) {
+		MinimapBlock& block = getBlock(pos);
+		Point offsetPos = getBlockOffset(Point(pos.x, pos.y));
+
+		//Create new cache object
+		MinimapCache minimapCache;
+		minimapCache.drawn = false;
+		minimapCache.minimapTile = minimapTile;
+		minimapCache.pos = pos;
+		minimapCache.block = &block;
+		minimapCache.offsetPos = offsetPos;
+
+		//In case the player object is not valid or we capable to view this tile, draw it without caching
+		if (localPlayer != nullptr && localPlayer->getPosition().z == pos.z && std::abs(localPlayer->getPosition().x - pos.x) <= 9 && std::abs(localPlayer->getPosition().y - pos.y) <= 7) {
+			block.updateTile(pos.x - offsetPos.x, pos.y - offsetPos.y, minimapTile);
+			block.justSaw();
+			return;
+		}
+
+		//In case we are not able to view the map tile or the player object is invalid, we should use our cache
+		minimapFloorCache[pos.z].push_back(minimapCache);
+	}
+
+	//Prevent the client from caching in case we are having an invalid player object
+	if(localPlayer == nullptr) {
+		return;
+	}
+
+	//Take a look inside our cache for the current players floor and check if there is data we can use
+	auto cacheIt = minimapFloorCache.find(localPlayer->getPosition().z);
+	if (cacheIt != minimapFloorCache.end()) {
+		//Now loop through the entire tile cache for this floor and draw the minimap for all tiles in range
+		auto &cache = minimapFloorCache[localPlayer->getPosition().z];
+		for (auto &it = cache.begin(); it != cache.end(); it++) {
+			//We might already have drawn this tile. Lets remove it to speed up everything
+			if (it->drawn == true) {
+				minimapFloorCache[localPlayer->getPosition().z].erase(it);
+				it = cache.begin();
+				continue;
+			}
+
+			//To prevent the Client from slowing down after a long playtime, remove all cached data which are outside our view range
+			if (std::abs(localPlayer->getPosition().x - it->pos.x) > 18 || std::abs(localPlayer->getPosition().y - it->pos.y) > 14) {
+				minimapDrawCache[it->pos] = MinimapTile();
+				minimapFloorCache[localPlayer->getPosition().z].erase(it);
+				it = cache.begin();
+				continue;
+			}
+
+			//Check if we are actually capable to view this tile from our current position and skip in case we are not
+			if (std::abs(localPlayer->getPosition().x - it->pos.x) > 9 || std::abs(localPlayer->getPosition().y - it->pos.y) > 7) {
+				continue;
+			}
+
+			//Looks like we passed all checks and are capable to view this tile. Lets draw the minimap data
+			it->block->updateTile(it->pos.x - it->offsetPos.x, it->pos.y - it->offsetPos.y, it->minimapTile);
+			it->block->justSaw();
+			it->drawn = true;
+			minimapFloorCache[localPlayer->getPosition().z].erase(it);
+		}
+	}
+#endif
 }
 
 const MinimapTile& Minimap::getTile(const Position& pos)
@@ -412,7 +500,7 @@ void Minimap::saveOtmm(const std::string& fileName)
                 fin->write(compressBuffer.data(), len);
             }
         }
-    
+
         // end of file
         Position invalidPos;
         fin->addU16(invalidPos.x);

--- a/src/client/minimap.h
+++ b/src/client/minimap.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2013 OTClient <https://github.com/edubart/otclient>
+ * Copyright (c) 2010-2014 OTClient <https://github.com/edubart/otclient>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -73,6 +73,15 @@ private:
     stdext::boolean<false> m_wasSeen;
 };
 
+struct MinimapCache
+{
+	bool drawn;
+	Position pos;
+	MinimapTile minimapTile;
+	Point offsetPos;
+	MinimapBlock* block;
+};
+
 #pragma pack(pop)
 
 class Minimap
@@ -107,6 +116,9 @@ private:
                                                                   (index / (65536 / MMBLOCK_SIZE))*MMBLOCK_SIZE, z); }
     uint getBlockIndex(const Position& pos) { return ((pos.y / MMBLOCK_SIZE) * (65536 / MMBLOCK_SIZE)) + (pos.x / MMBLOCK_SIZE); }
     std::unordered_map<uint, MinimapBlock> m_tileBlocks[Otc::MAX_Z+1];
+
+	std::map<uint, std::list<MinimapCache>> minimapFloorCache;
+	std::map<Position, MinimapTile> minimapDrawCache;
 };
 
 extern Minimap g_minimap;


### PR DESCRIPTION
Implemented a new feature called "Exploration Mode" which can be enabled by the compiler Flag EXPLORE_MODE, which will force players to explore the map in order to receive a fully drawn minimap. By default, OTClient will simply draw all received tiles from the server as minimap tiles allowing players to view lower and higher floors instantly. Some people might not want this and with this patch players will have to explore all floors in order to receive a correct minimap
