### PR TITLE
Hide item image box when editing house lists

### DIFF
--- a/modules/game_textwindow/textwindow.lua
+++ b/modules/game_textwindow/textwindow.lua
@@ -35,6 +35,10 @@ function onGameEditText(id, itemId, maxLength, text, writer, time)
 
   local textScroll = textWindow:getChildById('textScroll')
 
+  if textItem:isHidden() then
+    textItem:show()
+  end
+
   textItem:setItemId(itemId)
   textEdit:setMaxLength(maxLength)
   textEdit:setText(text)
@@ -106,6 +110,11 @@ function onGameEditList(id, doorId, text)
   local description = textWindow:getChildById('description')
   local okButton = textWindow:getChildById('okButton')
   local cancelButton = textWindow:getChildById('cancelButton')
+
+  local textItem = textWindow:getChildById('textItem')
+  if textItem and not textItem:isHidden() then
+    textItem:hide()
+  end
 
   textEdit:setMaxLength(8192)
   textEdit:setText(text)


### PR DESCRIPTION
Currently when editing the house lists, there's an empty image box that overlaps with the text edit area. This PR toggles the image depending on whether we're editing a regular text window or a house list.
