### PR TITLE
Support upper and lower case letters for hotkeys starting with #s, #y and #w

### DIFF
--- a/modules/game_console/console.lua
+++ b/modules/game_console/console.lua
@@ -679,7 +679,7 @@ function sendMessage(message, tab)
   local chatCommandMessage
 
   -- player used yell command
-  chatCommandMessage = message:match("^%#y (.*)")
+  chatCommandMessage = message:match("^%#[y|Y] (.*)")
   if chatCommandMessage ~= nil then
     chatCommandSayMode = 'yell'
     channel = 0
@@ -687,7 +687,7 @@ function sendMessage(message, tab)
   end
 
    -- player used whisper
-  local chatCommandMessage = message:match("^%#w (.*)")
+  local chatCommandMessage = message:match("^%#[w|W] (.*)")
   if chatCommandMessage ~= nil then
     chatCommandSayMode = 'whisper'
     message = chatCommandMessage
@@ -695,7 +695,7 @@ function sendMessage(message, tab)
   end
 
   -- player say
-  local chatCommandMessage = message:match("^%#s (.*)")
+  local chatCommandMessage = message:match("^%#[s|S] (.*)")
   if chatCommandMessage ~= nil then
     chatCommandSayMode = 'say'
     message = chatCommandMessage


### PR DESCRIPTION
CipSoft's client allows both lower and upper case letters when sending a message with #w, #y and #s pre-pended to the hotkey text. This PR makes it possible to do the same with otclient. While it's not critical, some people who are used to using the upper case variant might get confused as to why their hotkeys don't work properly.
