### PR TITLE
Fixing issue with actions after player death

### DIFF
--- a/modules/game_interface/gameinterface.lua
+++ b/modules/game_interface/gameinterface.lua
@@ -281,11 +281,9 @@ end
 
 function changeWalkDir(dir, pop)
 
-  if player then
-    if player:isDead() then
-      return
-	end
-  end  
+  if canPlayerPerformAction() == false then
+     return
+  end
 
   while table.removevalue(smartWalkDirs, dir) do end
   if pop then
@@ -319,11 +317,9 @@ end
 
 function smartWalk(dir)
 
-  if player then
-    if player:isDead() then
-      return
-	end
-  end  
+  if canPlayerPerformAction() == false then
+     return false
+  end 
 
   if g_keyboard.getModifiers() == KeyboardNoModifier then
     local func = walkFunction
@@ -618,11 +614,9 @@ end
 
 function processMouseAction(menuPosition, mouseButton, autoWalkPos, lookThing, useThing, creatureThing, attackCreature)
 
-  if player then
-    if player:isDead() then
-      return
-	end
-  end 
+  if canPlayerPerformAction() == false then
+     return false
+  end
 
   local keyboardModifiers = g_keyboard.getModifiers()
 
@@ -873,4 +867,15 @@ end
 
 function limitZoom()
   limitedZoom = true
+end
+
+function canPlayerPerformAction()
+  if not player then
+     return false
+  end
+  if player:isDead() then
+      return false
+  end 
+  
+  return true
 end


### PR DESCRIPTION
After a death of the player you still could move one tile away from your corpse making the client to draw the creature object again including all light effects. Up to that you still could perform actions with the mouse which the client displayed.
Up to that a cleanup was made, initialising the player object once he log ins preventing to have to call the function all over again.
Fixing issue #599