### PR TITLE
Update on textmessage.otui

### DIFF
--- a/modules/game_textmessage/textmessage.otui
+++ b/modules/game_textmessage/textmessage.otui
@@ -8,6 +8,7 @@ TextMessageLabel < UILabel
 
 Panel
   anchors.fill: gameMapPanel
+  anchors.bottom: gameBottomPanel.top
   focusable: false
 
   Panel


### PR DESCRIPTION
Change in the anchor statusLabel so that it is always on top of the console and never behind him.
When you press Ctrl + . you can not view the error messages .

Current version: http://prntscr.com/61k0wb
Correction: http://prntscr.com/61k0l3