### PR TITLE
Use native optimizations instead of hardcoded defaults

### DIFF
--- a/src/framework/CMakeLists.txt
+++ b/src/framework/CMakeLists.txt
@@ -170,7 +170,7 @@ set(CMAKE_CXX_FLAGS_COMPILESPEED      "-O0")
 set(CMAKE_CXX_FLAGS_DEBUG             "-O0 -g")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO    "-O1 -g -fno-omit-frame-pointer")
 set(CMAKE_CXX_FLAGS_RELEASE           "-O2")
-set(CMAKE_CXX_FLAGS_PERFORMANCE       "-Ofast -mmmx -msse -msse2")
+set(CMAKE_CXX_FLAGS_PERFORMANCE       "-Ofast -march=native")
 
 if(USE_LTO)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fwhole-program -flto")


### PR DESCRIPTION
Just like I noted in [this pull request](https://github.com/otland/forgottenserver/pull/1310) on otland/forgottenserver, we should use `-march=native` to turn on aggressive optimizations on best-performance builds. There were some hardcoded defaults in the CMakeLists which I have replaced with the improved flag.