### PR TITLE
Change when load and save occurs in gameinterface

### DIFF
--- a/modules/game_interface/gameinterface.lua
+++ b/modules/game_interface/gameinterface.lua
@@ -26,7 +26,12 @@ function init()
     onGameEnd = onGameEnd,
     onLoginAdvice = onLoginAdvice,
   }, true)
-
+  -- Call load AFTER game window has been created and resized to a stable state, otherwise the saved settings can get overridden by false onGeometryChange events
+  connect(g_app, {
+    onRun = load,
+    onExit = save
+  })
+  
   gameRootPanel = g_ui.displayUI('gameinterface')
   gameRootPanel:hide()
   gameRootPanel:lower()
@@ -49,7 +54,6 @@ function init()
   setupViewMode(0)
 
   bindKeys()
-  load()
 
   if g_game.isOnline() then
     show()
@@ -102,7 +106,6 @@ function unbindWalkKey(key)
 end
 
 function terminate()
-  save()
   hide()
 
   hookedMenuOptions = {}
@@ -146,7 +149,7 @@ function show()
   setupViewMode(0)
   updateStretchShrink()
   logoutButton:setTooltip(tr('Logout'))
-
+  
   addEvent(function()
     if not limitedZoom or g_game.isGM() then
       gameMapPanel:setMaxZoomOut(513)
@@ -479,7 +482,7 @@ function createThingMenu(menuPosition, lookThing, useThing, creatureThing)
       menu:addOption(tr('Browse Field'), function() g_game.browseField(useThing:getPosition()) end)
     end
   end
-
+  
   if lookThing and not lookThing:isCreature() and not lookThing:isNotMoveable() and lookThing:isPickupable() then
     menu:addSeparator()
     menu:addOption(tr('Trade with ...'), function() startTradeWith(lookThing) end)


### PR DESCRIPTION
Change when gameinterface calls load and save to prevent bottomSplitter from being put in the wrong location due to initial load resize events.

What was occurring was:
gameinterface module loaded and set bottomSplitter (between game window and chat) to the saved position.
onGeometryChanged event was called 3 times (I could not find the root cause of startup calling this, but probably due to loading if the window should be fullscreen or not. My client was setup to load to fullscreen, while windowed mode was very small). The onGemoetryChanged event changed where the bottomSplitter was (probably due to the small windowed mode that the game may "open" with for a few milliseconds).

Now what happens is:
gameinterface module loads
initial onGeometryChanged events are called
when g_app.onRun is called the splitter settings are loaded.

I moved the save to occur on the g_app.onExit for symmetry.