### PR TITLE
remake Visual Project

### DIFF
--- a/modules/game_market/market.otui
+++ b/modules/game_market/market.otui
@@ -1,7 +1,7 @@
 MarketWindow < MainWindow
   id: marketWindow
   !text: tr('Market')
-  size: 700 530
+  size: 800 530
 
   @onEscape: Market.close()
 
@@ -58,5 +58,5 @@ MarketWindow < MainWindow
     anchors.top: mainTabContent.bottom
     anchors.left: mainTabContent.left
     margin-top: 5
-    width: 110
+    text-auto-resize: true
     @onClick: Market.reset()

--- a/modules/game_market/ui/general/marketbuttons.otui
+++ b/modules/game_market/ui/general/marketbuttons.otui
@@ -2,6 +2,7 @@ MarketButtonBox < ButtonBoxRounded
   font: verdana-11px-rounded
   color: #f55e5ebb
   size: 106 22
+  text-auto-resize: true
   text-offset: 0 2
   text-align: center
 

--- a/modules/game_market/ui/marketoffers.otui
+++ b/modules/game_market/ui/marketoffers.otui
@@ -9,7 +9,8 @@ Panel
 
   Panel
     id: leftTabContent
-    width: 180
+    width: 240
+    
     anchors.top: prev.bottom
     anchors.left: prev.left
     anchors.bottom: parent.bottom
@@ -80,7 +81,7 @@ Panel
     anchors.top: prev.bottom
     anchors.left: createLabel.left
     margin-top: 3
-    width: 105
+    width: 115
 
     $disabled:
       color: #aaaaaa44
@@ -99,7 +100,7 @@ Panel
     anchors.top: prev.bottom
     anchors.left: prev.left
     margin-top: 3
-    width: 75
+    width: 80
     minimum: 1
     maximum: 999999999
     focusable: true
@@ -168,7 +169,7 @@ Panel
     anchors.verticalCenter: prev.verticalCenter
     anchors.left: prev.right
     margin-left: 7
-    width: 90
+    text-auto-resize: true
 
   CheckBox
     id: anonymousCheckBox

--- a/modules/game_market/ui/marketoffers/browse.otui
+++ b/modules/game_market/ui/marketoffers/browse.otui
@@ -34,18 +34,14 @@ Panel
     anchors.top: parent.top
     anchors.left: parent.left
     anchors.right: parent.right
-    margin-top: 3
-    margin-right: 3
-    margin-left: 3
+    margin: 3 3 0 3
 
   MarketComboBox
     id: subCategoryComboBox
     anchors.top: prev.bottom
     anchors.left: parent.left
     anchors.right: parent.right
-    margin-top: 3
-    margin-right: 3
-    margin-left: 3
+    margin: 3 3 0 3
 
     $disabled:
       color: #aaaaaa44
@@ -57,12 +53,10 @@ Panel
     !tooltip: tr('Filter list to match your level')
     anchors.top: prev.bottom
     anchors.left: parent.left
-    margin-top: 3
-    margin-right: 3
+    padding: 4 3 0 3
     margin-left: 3
-    width: 40
-    height: 20
-
+    text-auto-resize: true
+    
   MarketButtonBox
     id: filterVocation
     &default: false
@@ -70,10 +64,9 @@ Panel
     !tooltip: tr('Filter list to match your vocation')
     anchors.top: prev.top
     anchors.left: prev.right
-    margin-right: 3
+    padding: 4 3 0 3
     margin-left: 3
-    width: 34
-    height: 20
+    text-auto-resize: true
 
   MarketComboBox
     id: slotComboBox
@@ -94,9 +87,7 @@ Panel
     anchors.top: prev.bottom
     anchors.left: parent.left
     anchors.right: parent.right
-    margin-top: 6
-    margin-right: 3
-    margin-left: 3
+    margin: 6 3 0 3
 
   Panel
     id: itemsContainer
@@ -104,10 +95,7 @@ Panel
     anchors.left: parent.left
     anchors.right: parent.right
     anchors.bottom: parent.bottom
-    margin-top: 10
-    margin-left: 3
-    margin-bottom: 30
-    margin-right: 3
+    margin: 10 3 30 3
 
     VerticalScrollBar
       id: itemsPanelListScrollBar
@@ -135,7 +123,7 @@ Panel
     anchors.top: prev.bottom
     anchors.left: prev.left
     margin-top: 9
-    width: 30
+    text-auto-resize: true
     font: verdana-11px-rounded
     text-offset: 0 2
 

--- a/modules/game_market/ui/marketoffers/itemdetails.otui
+++ b/modules/game_market/ui/marketoffers/itemdetails.otui
@@ -26,10 +26,7 @@ Panel
     anchors.bottom: parent.bottom
     anchors.left: parent.left
     anchors.right: parent.right
-    margin-top: 63
-    margin-left: 6
-    margin-bottom: 85
-    margin-right: 6
+    margin: 63 6 85 6
     padding: 1
     focusable: false
     background-color: #222833

--- a/modules/game_market/ui/marketoffers/itemoffers.otui
+++ b/modules/game_market/ui/marketoffers/itemoffers.otui
@@ -37,7 +37,7 @@ Panel
     anchors.right: parent.right
     anchors.bottom: next.bottom
     margin-right: 6
-    width: 80
+    text-auto-resize: true
     enabled: false
 
   Label
@@ -55,9 +55,7 @@ Panel
     anchors.left: prev.left
     anchors.right: parent.right
     height: 115
-    margin-top: 5
-    margin-bottom: 5
-    margin-right: 6
+    margin: 5 6 5 0
     padding: 1
     focusable: false
     background-color: #222833
@@ -73,19 +71,19 @@ Panel
       id: header
       OfferTableHeaderColumn
         !text: tr('Buyer Name')
-        width: 100
+        text-auto-resize: true
       OfferTableHeaderColumn
         !text: tr('Amount')
-        width: 60
+        text-auto-resize: true
       OfferTableHeaderColumn
         !text: tr('Total Price')
-        width: 90
+        text-auto-resize: true
       OfferTableHeaderColumn
         !text: tr('Piece Price')
-        width: 80
+        text-auto-resize: true
       OfferTableHeaderColumn
         !text: tr('Auction End')
-        width: 120
+        text-auto-resize: true
 
   TableData
     id: sellingTableData
@@ -110,7 +108,7 @@ Panel
     anchors.top: prev.bottom
     margin-top: 5
     margin-right: 6
-    width: 80
+    text-auto-resize: true
     enabled: false
 
   Label
@@ -127,6 +125,7 @@ Panel
     anchors.top: prev.bottom
     anchors.left: prev.left
     anchors.right: parent.right
+    margin: 5 6 5 0
     margin-top: 5
     margin-bottom: 5
     margin-right: 6
@@ -146,19 +145,19 @@ Panel
       id: header
       OfferTableHeaderColumn
         !text: tr('Seller Name')
-        width: 100
+        text-auto-resize: true
       OfferTableHeaderColumn
         !text: tr('Amount')
-        width: 60
+        text-auto-resize: true
       OfferTableHeaderColumn
         !text: tr('Total Price')
-        width: 90
+        text-auto-resize: true
       OfferTableHeaderColumn
         !text: tr('Piece Price')
-        width: 80
+        text-auto-resize: true
       OfferTableHeaderColumn
         !text: tr('Auction End')
-        width: 120
+        text-auto-resize: true
 
   TableData
     id: buyingTableData

--- a/modules/game_market/ui/marketoffers/itemstats.otui
+++ b/modules/game_market/ui/marketoffers/itemstats.otui
@@ -32,9 +32,7 @@ Panel
     anchors.top: prev.bottom
     anchors.left: prev.left
     anchors.right: prev.right
-    margin-top: 6
-    margin-bottom: 5
-    margin-right: 6
+    margin: 6 6 5 0
     height: 121
     padding: 1
     focusable: false

--- a/modules/game_market/ui/marketoffers/overview.otui
+++ b/modules/game_market/ui/marketoffers/overview.otui
@@ -7,9 +7,7 @@ Panel
     anchors.top: parent.top
     anchors.left: parent.left
     anchors.right: parent.right
-    margin-top: 6
-    margin-left: 6
-    margin-right: 6
+    margin: 6 6 0 6
     font: verdana-11px-rounded
     text-offset: 0 2
     height: 50

--- a/modules/game_market/ui/myoffers/currentoffers.otui
+++ b/modules/game_market/ui/myoffers/currentoffers.otui
@@ -55,9 +55,7 @@ Panel
     anchors.left: prev.left
     anchors.right: parent.right
     height: 150
-    margin-top: 5
-    margin-bottom: 5
-    margin-right: 6
+    margin: 5 6 5 0
     padding: 1
     focusable: false
     background-color: #222833
@@ -127,9 +125,7 @@ Panel
     anchors.top: prev.bottom
     anchors.left: prev.left
     anchors.right: parent.right
-    margin-top: 5
-    margin-bottom: 5
-    margin-right: 6
+    margin: 5 6 5 0
     height: 150
     padding: 1
     focusable: false

--- a/src/framework/sound/declarations.h
+++ b/src/framework/sound/declarations.h
@@ -27,8 +27,8 @@
 
 #define AL_LIBTYPE_STATIC
 
-#include <al.h>
-#include <alc.h>
+#include <Al/al.h>
+#include <Al/alc.h>
 
 class SoundManager;
 class SoundSource;

--- a/src/framework/sound/declarations.h
+++ b/src/framework/sound/declarations.h
@@ -27,8 +27,13 @@
 
 #define AL_LIBTYPE_STATIC
 
+#ifdef _MSC_VER
 #include <Al/al.h>
 #include <Al/alc.h>
+#else
+#include <al.h>
+#include <alc.h>
+#endif
 
 class SoundManager;
 class SoundSource;

--- a/vc12/arch32.props
+++ b/vc12/arch32.props
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup>
+    <Link>
+      <AdditionalLibraryDirectories>$(OTCLIENT_LIBS)</AdditionalLibraryDirectories>
+      <LargeAddressAware>true</LargeAddressAware>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup />
+</Project>

--- a/vc12/arch64.props
+++ b/vc12/arch64.props
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup>
+    <Link>
+      <AdditionalLibraryDirectories>$(OTCLIENT_LIBS64)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup />
+</Project>

--- a/vc12/debug.props
+++ b/vc12/debug.props
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <OutDir>$(ProjectDir)../</OutDir>
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <WholeProgramOptimization>false</WholeProgramOptimization>
+      <MinimalRebuild>false</MinimalRebuild>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <ObjectFileName>$(IntDir)\obj_r\%(RelativeDir)</ObjectFileName>
+	  <AdditionalOptions>/bigobj%(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>$(OTCLIENT_LIBDEPS_D)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup />
+</Project>
+

--- a/vc12/otclient.vcxproj
+++ b/vc12/otclient.vcxproj
@@ -21,7 +21,7 @@
   <PropertyGroup Label="Globals">
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{17A8F78F-1FFB-4128-A3B3-59CC6C19D89A}</ProjectGuid>
-	<RootNamespace>otclient</RootNamespace>
+    <RootNamespace>otclient</RootNamespace>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/vc12/otclient.vcxproj
+++ b/vc12/otclient.vcxproj
@@ -82,7 +82,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <PreprocessorDefinitions>$(PREPROCESSOR_DEFS);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>$(PREPROCESSOR_DEFS);_SCL_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <Optimization>Disabled</Optimization>
     </ClCompile>
@@ -93,7 +93,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>$(PREPROCESSOR_DEFS);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>$(PREPROCESSOR_DEFS);_SCL_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>

--- a/vc12/otclient.vcxproj
+++ b/vc12/otclient.vcxproj
@@ -19,144 +19,110 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
+    <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{17A8F78F-1FFB-4128-A3B3-59CC6C19D89A}</ProjectGuid>
-    <RootNamespace>otclient</RootNamespace>
+	<RootNamespace>otclient</RootNamespace>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v120</PlatformToolset>
-    <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v120</PlatformToolset>
-    <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v120</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v120</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="settings.props" />
+    <Import Project="arch32.props" />
+    <Import Project="debug.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="settings.props" />
+    <Import Project="arch64.props" />
+    <Import Project="debug.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="settings.props" />
+    <Import Project="arch32.props" />
+    <Import Project="release.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="settings.props" />
+    <Import Project="arch64.props" />
+    <Import Project="release.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <IncludePath>D:\otclient-msvc13-libs\libogg-1.3.1\include;D:\otclient-msvc13-libs\libvorbis-1.3.3\include;D:\otclient-msvc13-libs\physfs-2.0.3\include;D:\otclient-msvc13-libs\OpenSSL-1.0.1e\include;D:\otclient-msvc13-libs\zlib-1.2.5\include;D:\otclient-msvc13-libs\OpenAL\include\AL;D:\otclient-msvc13-libs\glew-1.10.0\include;D:\otclient-msvc13-libs\LuaJIT-2.0.2\include;D:\otclient-msvc13-libs\boost_1_55_0\include;D:\otclient\src;..\src;$(IncludePath)</IncludePath>
-    <LibraryPath>D:\otclient-msvc13-libs\libogg-1.3.1\lib;D:\otclient-msvc13-libs\libvorbis-1.3.3\lib;D:\otclient-msvc13-libs\physfs-2.0.3\lib;D:\otclient-msvc13-libs\OpenSSL-1.0.1e\lib\VC;D:\otclient-msvc13-libs\zlib-1.2.5\lib;D:\otclient-msvc13-libs\OpenAL\lib;D:\otclient-msvc13-libs\LuaJIT-2.0.2\lib;D:\otclient-msvc13-libs\glew-1.10.0\lib;D:\otclient-msvc13-libs\boost_1_55_0\lib;$(LibraryPath)</LibraryPath>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);../src;</IncludePath>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <IncludePath>D:\otclient-msvc13-libs\libogg-1.3.1\include;D:\otclient-msvc13-libs\libvorbis-1.3.3\include;D:\otclient-msvc13-libs\physfs-2.0.3\include;D:\otclient-msvc13-libs\OpenSSL-1.0.1e\include;D:\otclient-msvc13-libs\zlib-1.2.5\include;D:\otclient-msvc13-libs\OpenAL\include\AL;D:\otclient-msvc13-libs\glew-1.10.0\include;D:\otclient-msvc13-libs\LuaJIT-2.0.2\include;D:\otclient-msvc13-libs\boost_1_55_0\include;D:\otclient\src;..\src;$(IncludePath)</IncludePath>
-    <LibraryPath>D:\otclient-msvc13-libs\libogg-1.3.1\lib;D:\otclient-msvc13-libs\libvorbis-1.3.3\lib;D:\otclient-msvc13-libs\physfs-2.0.3\lib;D:\otclient-msvc13-libs\OpenSSL-1.0.1e\lib\VC;D:\otclient-msvc13-libs\zlib-1.2.5\lib;D:\otclient-msvc13-libs\OpenAL\lib;D:\otclient-msvc13-libs\LuaJIT-2.0.2\lib;D:\otclient-msvc13-libs\glew-1.10.0\lib;D:\otclient-msvc13-libs\boost_1_55_0\lib;$(LibraryPath)</LibraryPath>
-  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <IncludePath>C:\otclient-msvc13-libs\libogg-1.3.1\include;C:\otclient-msvc13-libs\libvorbis-1.3.3\include;C:\otclient-msvc13-libs\physfs-2.0.3\include;C:\otclient-msvc13-libs\OpenSSL-1.0.1e\include;C:\otclient-msvc13-libs\zlib-1.2.5\include;C:\otclient-msvc13-libs\OpenAL\include\AL;C:\otclient-msvc13-libs\glew-1.10.0\include;C:\otclient-msvc13-libs\LuaJIT-2.0.2\include;C:\otclient-msvc13-libs\boost_1_55_0\include;..\src;$(IncludePath)</IncludePath>
-    <LibraryPath>C:\otclient-msvc13-libs\libogg-1.3.1\lib;C:\otclient-msvc13-libs\libvorbis-1.3.3\lib;C:\otclient-msvc13-libs\physfs-2.0.3\lib;C:\otclient-msvc13-libs\OpenSSL-1.0.1e\lib\VC;C:\otclient-msvc13-libs\zlib-1.2.5\lib;C:\otclient-msvc13-libs\OpenAL\lib;C:\otclient-msvc13-libs\LuaJIT-2.0.2\lib;C:\otclient-msvc13-libs\glew-1.10.0\lib;C:\otclient-msvc13-libs\boost_1_55_0\lib;$(LibraryPath)</LibraryPath>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);../src;</IncludePath>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <IncludePath>D:\otclient-msvc13-libs\libogg-1.3.1\include;D:\otclient-msvc13-libs\libvorbis-1.3.3\include;D:\otclient-msvc13-libs\physfs-2.0.3\include;D:\otclient-msvc13-libs\OpenSSL-1.0.1e\include;D:\otclient-msvc13-libs\zlib-1.2.5\include;D:\otclient-msvc13-libs\OpenAL\include\AL;D:\otclient-msvc13-libs\glew-1.10.0\include;D:\otclient-msvc13-libs\LuaJIT-2.0.2\include;D:\otclient-msvc13-libs\boost_1_55_0\include;D:\otclient\src;..\src;$(IncludePath)</IncludePath>
-    <LibraryPath>D:\otclient-msvc13-libs\libogg-1.3.1\lib;D:\otclient-msvc13-libs\libvorbis-1.3.3\lib;D:\otclient-msvc13-libs\physfs-2.0.3\lib;D:\otclient-msvc13-libs\OpenSSL-1.0.1e\lib\VC;D:\otclient-msvc13-libs\zlib-1.2.5\lib;D:\otclient-msvc13-libs\OpenAL\lib;D:\otclient-msvc13-libs\LuaJIT-2.0.2\lib;D:\otclient-msvc13-libs\glew-1.10.0\lib;D:\otclient-msvc13-libs\boost_1_55_0\lib;$(LibraryPath)</LibraryPath>
-  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>$(PREPROCESSOR_DEFS);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <Optimization>Disabled</Optimization>
-      <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0501;BOT_PROTECTION;CLIENT;CRASH_HANDLER;FW_GRAPHICS;FW_NET;FW_SOUND;FW_XML;BUILD_TYPE="RelWithDebInfo";BUILD_COMMIT="devel";BUILD_REVISION="0";VERSION="0.6.3";"BUILD_REVISION=\"0\"";"VERSION=\"0.6.3\"";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ObjectFileName>$(IntDir)\$(Platform)\src\%(RelativeDir)\</ObjectFileName>
     </ClCompile>
     <Link>
+      <TargetMachine>MachineX86</TargetMachine>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <IgnoreSpecificDefaultLibraries>libcmt.lib</IgnoreSpecificDefaultLibraries>
-      <AdditionalDependencies>glew32.lib;zlib1.lib;libeay32MD.lib;physfs.lib;openal32.lib;luajit.lib;libogg_static.lib;libvorbisfile_static.lib;libvorbis_static.lib;opengl32.lib;dbghelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <LargeAddressAware>true</LargeAddressAware>
-      <SubSystem>Windows</SubSystem>
-      <EntryPointSymbol>mainCRTStartup</EntryPointSymbol>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
-      <Optimization>Disabled</Optimization>
-      <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0501;BOT_PROTECTION;CLIENT;CRASH_HANDLER;FW_GRAPHICS;FW_NET;FW_SOUND;FW_XML;BUILD_TYPE="RelWithDebInfo";BUILD_COMMIT="devel";BUILD_REVISION="0";VERSION="0.6.3";"BUILD_REVISION=\"0\"";"VERSION=\"0.6.3\"";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ObjectFileName>$(IntDir)\$(Platform)\src\%(RelativeDir)\</ObjectFileName>
+      <PreprocessorDefinitions>$(PREPROCESSOR_DEFS);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <IgnoreSpecificDefaultLibraries>libcmt.lib</IgnoreSpecificDefaultLibraries>
-      <AdditionalDependencies>glew32.lib;zlib1.lib;libeay32MD.lib;physfs.lib;openal32.lib;luajit.lib;libogg_static.lib;libvorbisfile_static.lib;libvorbis_static.lib;opengl32.lib;dbghelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <LargeAddressAware>true</LargeAddressAware>
-      <SubSystem>Windows</SubSystem>
-      <EntryPointSymbol>mainCRTStartup</EntryPointSymbol>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
-      <Optimization>MaxSpeed</Optimization>
-      <FunctionLevelLinking>true</FunctionLevelLinking>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0501;BOT_PROTECTION;CLIENT;CRASH_HANDLER;FW_GRAPHICS;FW_NET;FW_SOUND;FW_XML;BUILD_TYPE="RelWithDebInfo";BUILD_COMMIT="devel";BUILD_REVISION="0";VERSION="0.6.3";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ObjectFileName>$(IntDir)\$(Platform)\src\%(RelativeDir)\</ObjectFileName>
+      <PreprocessorDefinitions>$(PREPROCESSOR_DEFS);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
+      <TargetMachine>MachineX86</TargetMachine>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>glew32.lib;zlib1.lib;libeay32MD.lib;physfs.lib;openal32.lib;luajit.lib;libogg_static.lib;libvorbisfile_static.lib;libvorbis_static.lib;opengl32.lib;dbghelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <SubSystem>Windows</SubSystem>
-      <EntryPointSymbol>mainCRTStartup</EntryPointSymbol>
-      <IgnoreSpecificDefaultLibraries>libcmt.lib</IgnoreSpecificDefaultLibraries>
-      <LargeAddressAware>true</LargeAddressAware>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
-      <Optimization>MaxSpeed</Optimization>
-      <FunctionLevelLinking>true</FunctionLevelLinking>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0501;BOT_PROTECTION;CLIENT;CRASH_HANDLER;FW_GRAPHICS;FW_NET;FW_SOUND;FW_XML;BUILD_TYPE="RelWithDebInfo";BUILD_COMMIT="devel";BUILD_REVISION="0";VERSION="0.6.3";%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <ObjectFileName>$(IntDir)\$(Platform)\src\%(RelativeDir)\</ObjectFileName>
+      <PreprocessorDefinitions>$(PREPROCESSOR_DEFS);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <WarningLevel>Level4</WarningLevel>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>glew32.lib;zlib1.lib;libeay32MD.lib;physfs.lib;openal32.lib;luajit.lib;libogg_static.lib;libvorbisfile_static.lib;libvorbis_static.lib;opengl32.lib;dbghelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <SubSystem>Windows</SubSystem>
-      <EntryPointSymbol>mainCRTStartup</EntryPointSymbol>
-      <IgnoreSpecificDefaultLibraries>libcmt.lib</IgnoreSpecificDefaultLibraries>
-      <LargeAddressAware>true</LargeAddressAware>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -253,10 +219,7 @@
     <ClCompile Include="..\src\framework\luaengine\luaexception.cpp" />
     <ClCompile Include="..\src\framework\luaengine\luainterface.cpp" />
     <ClCompile Include="..\src\framework\luaengine\luaobject.cpp" />
-    <ClCompile Include="..\src\framework\luaengine\luavaluecasts.cpp">
-      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(InputDir)\$(IntDir)\</ObjectFileName>
-      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(InputDir)\$(IntDir)\</ObjectFileName>
-    </ClCompile>
+    <ClCompile Include="..\src\framework\luaengine\luavaluecasts.cpp" />
     <ClCompile Include="..\src\framework\luafunctions.cpp" />
     <ClCompile Include="..\src\framework\net\connection.cpp" />
     <ClCompile Include="..\src\framework\net\inputmessage.cpp" />

--- a/vc12/register_OtClientSdk_env.bat
+++ b/vc12/register_OtClientSdk_env.bat
@@ -1,0 +1,1 @@
+setx OTCLIENTSDKDir %CD%

--- a/vc12/register_boost_env.bat
+++ b/vc12/register_boost_env.bat
@@ -1,0 +1,1 @@
+setx BOOST_ROOT %CD%

--- a/vc12/release.props
+++ b/vc12/release.props
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <OutDir>$(ProjectDir)../</OutDir>
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <Optimization>Full</Optimization>
+      <ObjectFileName>$(IntDir)\obj_r\%(RelativeDir)</ObjectFileName>
+    </ClCompile>
+    <Link>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup />
+</Project>
+

--- a/vc12/settings.props
+++ b/vc12/settings.props
@@ -1,0 +1,187 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros">
+    <LUA_DIR>$(OTCLIENTSDKDir)\LuaJIT-2.0.2\</LUA_DIR>
+    <GLEW_DIR>$(OTCLIENTSDKDir)\glew-1.10.0\</GLEW_DIR>
+    <LIBOGG_DIR>$(OTCLIENTSDKDir)\libogg-1.3.1\</LIBOGG_DIR>
+    <LIBVORBIS_DIR>$(OTCLIENTSDKDir)\libvorbis-1.3.3\</LIBVORBIS_DIR>
+    <OPEN_AL_DIR>$(OTCLIENTSDKDir)\OpenAL\</OPEN_AL_DIR>
+    <OPEN_SSL_DIR>$(OTCLIENTSDKDir)\OpenSSL-1.0.1e\</OPEN_SSL_DIR>
+    <PHYSFS_DIR>$(OTCLIENTSDKDir)\physfs-2.0.3\</PHYSFS_DIR>
+    <ZLIB_DIR>$(OTCLIENTSDKDir)\zlib-1.2.5\</ZLIB_DIR>
+    
+    <PREPROCESSOR_DEFS>
+        WIN32;
+        _CRT_SECURE_NO_WARNINGS;
+        _WIN32_WINNT=0x0501;
+        BOT_PROTECTION;
+        OTCLIENT;
+        CRASH_HANDLER;
+        FW_GRAPHICS;
+        FW_NET;
+        FW_SOUND;
+        FW_XML;
+        BUILD_TYPE="RelWithDebInfo";
+        BUILD_COMMIT="devel";
+        BUILD_REVISION="0";
+        VERSION="0.6.3"
+    </PREPROCESSOR_DEFS>
+    
+    <OTCLIENT_INCLUDES>
+        $(BOOST_ROOT);
+        $(LUA_DIR)\include;
+        $(GLEW_DIR)\include;
+        $(LIBOGG_DIR)\include;
+        $(LIBVORBIS_DIR)\include;
+        $(OPEN_AL_DIR)\include;
+        $(OPEN_SSL_DIR)\include;
+        $(PHYSFS_DIR)\include;
+        $(ZLIB_DIR)\include
+    </OTCLIENT_INCLUDES>
+    
+    <OTCLIENT_LIBS>
+        $(BOOST_ROOT)\lib32-msvc-12.0;
+        $(LUA_DIR)\lib;
+        $(GLEW_DIR)\lib;
+        $(LIBOGG_DIR)\lib;
+        $(LIBVORBIS_DIR)\lib;
+        $(OPEN_AL_DIR)\lib;
+        $(OPEN_SSL_DIR)\lib\VC;
+        $(PHYSFS_DIR)\lib;
+        $(ZLIB_DIR)\lib
+    </OTCLIENT_LIBS>
+    
+    <OTCLIENT_LIBS64>
+        $(BOOST_ROOT)\lib64-msvc-12.0;
+        $(LUA_DIR)\lib64;
+        $(GLEW_DIR)\lib64;
+        $(LIBOGG_DIR)\lib64;
+        $(LIBVORBIS_DIR)\lib64;
+        $(OPEN_AL_DIR)\lib64;
+        $(OPEN_SSL_DIR)\lib64;
+        $(PHYSFS_DIR)\lib64;
+        $(ZLIB_DIR)\lib64
+    </OTCLIENT_LIBS64>
+    
+    <OTCLIENT_LIBDEPS>
+        glew32.lib;
+        zlib1.lib;
+        libeay32MD.lib;
+        physfs.lib;
+        openal32.lib;
+        luajit.lib;
+        libogg_static.lib;
+        libvorbisfile_static.lib;
+        libvorbis_static.lib;
+        opengl32.lib;
+        dbghelp.lib;
+		kernel32.lib;
+		user32.lib;
+		shell32.lib;
+		gdi32.lib;
+		advapi32.lib;
+    </OTCLIENT_LIBDEPS>
+    
+    <OTCLIENT_LIBDEPS_D>
+        glew32.lib;
+        zlib1.lib;
+        libeay32MDd.lib;
+        physfs.lib;
+        openal32.lib;
+        luajit.lib;
+        libogg_static.lib;
+        libvorbisfile_static.lib;
+        libvorbis_static.lib;
+        opengl32.lib;
+        dbghelp.lib;
+		kernel32.lib;
+		user32.lib;
+		shell32.lib;
+		gdi32.lib;
+		advapi32.lib;
+	</OTCLIENT_LIBDEPS_D>
+    
+  </PropertyGroup>
+  <PropertyGroup>
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(OTCLIENT_INCLUDES)</AdditionalIncludeDirectories>
+      <WarningLevel>Level3</WarningLevel>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <WholeProgramOptimization>true</WholeProgramOptimization>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>$(OTCLIENT_LIBDEPS)</AdditionalDependencies>
+      <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
+      <IgnoreSpecificDefaultLibraries>libcmt.lib</IgnoreSpecificDefaultLibraries>
+      <LargeAddressAware>true</LargeAddressAware>
+      <SubSystem>Windows</SubSystem>
+      <EntryPointSymbol>mainCRTStartup</EntryPointSymbol>
+    </Link>
+    <!-- <ResourceCompile>
+      <PreprocessorDefinitions>$(PREPROCESSOR_DEFS)</PreprocessorDefinitions>
+    </ResourceCompile> -->
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <BuildMacro Include="LUA_DIR">
+      <Value>$(LUA_DIR)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>
+    <BuildMacro Include="GLEW_DIR">
+      <Value>$(GLEW_DIR)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>
+    <BuildMacro Include="LIBOGG_DIR">
+      <Value>$(LIBOGG_DIR)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>
+    <BuildMacro Include="LIBVORBIS_DIR">
+      <Value>$(LIBVORBIS_DIR)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>
+    <BuildMacro Include="OPEN_AL_DIR">
+      <Value>$(OPEN_AL_DIR)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>
+    <BuildMacro Include="OPEN_SSL_DIR">
+      <Value>$(OPEN_SSL_DIR)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>
+    <BuildMacro Include="PHYSFS_DIR">
+      <Value>$(PHYSFS_DIR)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>
+    <BuildMacro Include="ZLIB_DIR">
+      <Value>$(ZLIB_DIR)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>
+    
+    <BuildMacro Include="PREPROCESSOR_DEFS">
+      <Value>$(PREPROCESSOR_DEFS)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>
+    <BuildMacro Include="OTCLIENT_INCLUDES">
+      <Value>$(OTCLIENT_INCLUDES)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>
+    <BuildMacro Include="OTCLIENT_LIBS">
+      <Value>$(OTCLIENT_LIBS)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>
+    <BuildMacro Include="OTCLIENT_LIBS64">
+      <Value>$(OTCLIENT_LIBS64)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>
+    <BuildMacro Include="OTCLIENT_LIBDEPS">
+      <Value>$(OTCLIENT_LIBDEPS)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>
+    <BuildMacro Include="OTCLIENT_LIBDEPS_D">
+      <Value>$(OTCLIENT_LIBDEPS_D)</Value>
+    </BuildMacro>
+  </ItemGroup>
+</Project>

--- a/vc12/settings.props
+++ b/vc12/settings.props
@@ -76,11 +76,11 @@
         libvorbis_static.lib;
         opengl32.lib;
         dbghelp.lib;
-		kernel32.lib;
-		user32.lib;
-		shell32.lib;
-		gdi32.lib;
-		advapi32.lib;
+        kernel32.lib;
+        user32.lib;
+        shell32.lib;
+        gdi32.lib;
+        advapi32.lib;
     </OTCLIENT_LIBDEPS>
     
     <OTCLIENT_LIBDEPS_D>
@@ -95,11 +95,11 @@
         libvorbis_static.lib;
         opengl32.lib;
         dbghelp.lib;
-		kernel32.lib;
-		user32.lib;
-		shell32.lib;
-		gdi32.lib;
-		advapi32.lib;
+        kernel32.lib;
+        user32.lib;
+        shell32.lib;
+        gdi32.lib;
+        advapi32.lib;
 	</OTCLIENT_LIBDEPS_D>
     
   </PropertyGroup>


### PR DESCRIPTION
changes in market: some windows are larger
buttons etc, will resize depending on client language

iam using boost from http://sourceforge.net/projects/boost/files/boost-binaries/1.57.0/
boost_1_57_0-msvc-12.0-32.exe

this changes in vc12 make possibility to debug, debug working on my own compiled dll like libvorbis
sdk allowed by you dont work to do debug, for release is good

So loords of otclient :smile_cat:  please relase new sdk for otclient (32bit with debug info and without, and 64bit with debug info and without)
and be free to using breakpoint.

new Edit!!!:
you dont have to do new sdk i missed one dll
be sure you check: tools->options->debugging->symbols 
now you can debug !!!!