### PR TITLE
Log file saves specific to server and character

### DIFF
--- a/modules/game_console/console.lua
+++ b/modules/game_console/console.lua
@@ -709,6 +709,8 @@ function processChannelTabMenu(tab, mousePos, mouseButton)
   local menu = g_ui.createWidget('PopupMenu')
   menu:setGameMenu(true)
 
+  worldName = g_game.getWorldName()
+  characterName = g_game.getCharacterName()
   channelName = tab:getText()
   if tab ~= defaultTab and tab ~= serverTab then
     menu:addOption(tr('Close'), function() removeTab(channelName) end)
@@ -726,7 +728,7 @@ function processChannelTabMenu(tab, mousePos, mouseButton)
         table.insert(lines, label:getText())
       end
 
-      local filename = channelName .. '.txt'
+      local filename = worldName .. ' - ' .. characterName .. ' - ' .. channelName .. '.txt'
       local filepath = '/' .. filename
 
       -- extra information at the beginning


### PR DESCRIPTION
Changed it so when you save a log file, the log file name includes the
server name and the characters name, in the file name.

This is to improve organization, to separate logs based off the server
you are on, and the character you are logged in.
