### PR TITLE
Properly check tile elevation in older protocols

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -654,6 +654,12 @@ bool Game::walk(Otc::Direction direction, bool dash)
 
     m_localPlayer->stopAutoWalk();
 
+    if(getClientVersion() <= 740) {
+        const TilePtr fromTile = g_map.getTile(m_localPlayer->getPosition());
+        if (fromTile && toTile && (toTile->getElevation() - 1 > fromTile->getElevation()))
+            return false;
+    }
+
     g_lua.callGlobalField("g_game", "onWalk", direction, dash);
 
     forceWalk(direction);

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -166,6 +166,9 @@ void LocalPlayer::cancelWalk(Otc::Direction direction)
 
 bool LocalPlayer::autoWalk(const Position& destination)
 {
+    if(g_game.getClientVersion() <= 740 && m_position.isInRange(destination, 1, 1))
+        return g_game.walk(m_position.getDirectionFromPosition(destination));
+
     bool tryKnownPath = false;
     if(destination != m_autoWalkDestination) {
         m_knownCompletePath = false;

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -641,11 +641,7 @@ int Tile::getElevation() const
 
 bool Tile::hasElevation(int elevation)
 {
-    int count = 0;
-    for(const ThingPtr& thing : m_things)
-        if(thing->getElevation() > 0)
-            count++;
-    return count >= elevation;
+    return getElevation() >= elevation;
 }
 
 void Tile::checkTranslucentLight()

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -506,9 +506,6 @@ bool Tile::isWalkable(bool ignoreCreatures)
     if(!getGround())
         return false;
 
-    if(g_game.getClientVersion() <= 740 && hasElevation(2))
-        return false;
-
     for(const ThingPtr& thing : m_things) {
         if(thing->isNotWalkable())
             return false;
@@ -631,6 +628,15 @@ bool Tile::limitsFloorsView(bool isFreeView)
 bool Tile::canErase()
 {
     return m_walkingCreatures.empty() && m_effects.empty() && m_things.empty() && m_flags == 0 && m_minimapColor == 0;
+}
+
+int Tile::getElevation() const
+{
+    int elevation = 0;
+    for(const ThingPtr& thing : m_things)
+        if(thing->getElevation() > 0)
+            elevation++;
+    return elevation;
 }
 
 bool Tile::hasElevation(int elevation)

--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -109,6 +109,7 @@ public:
     bool hasCreature();
     bool limitsFloorsView(bool isFreeView = false);
     bool canErase();
+    int getElevation() const;
     bool hasElevation(int elevation = 1);
     void overwriteMinimapColor(uint8 color) { m_minimapColor = color; }
 


### PR DESCRIPTION
As the title says. Feedback welcome. LocalPlayer change is to take care of walking with mouse click.
