### PR TITLE
Fixed issue in function fitAll

### DIFF
--- a/modules/corelib/ui/uiminiwindowcontainer.lua
+++ b/modules/corelib/ui/uiminiwindowcontainer.lua
@@ -69,7 +69,7 @@ function UIMiniWindowContainer:fitAll(noRemoveChild)
     end
 
     local child = children[i]
-    if child ~= noRemoveChild then
+    if child ~= noRemoveChild and child:isVisible() then
       local childHeight = child:getHeight()
       sumHeight = sumHeight - childHeight
       table.insert(removeChildren, child)


### PR DESCRIPTION
Mini windows containers was exceeding the size of the panels because they were considering the invisible windows as part of total height.