### PR TITLE
Replace deprecated c++11 test with cmake script

### DIFF
--- a/src/framework/CMakeLists.txt
+++ b/src/framework/CMakeLists.txt
@@ -157,11 +157,7 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "RelWithDebInfo")
 endif()
 
-if(WIN32)
-    set(CPP2011_FLAGS "-std=gnu++0x")
-else()
-    set(CPP2011_FLAGS "-std=c++0x")
-endif()
+include(FindCXX11)
 
 # gcc compile flags
 set(WARNS_FLAGS "-Wall -Wextra -Wno-unused-parameter -Wno-unused-variable -Wno-unused-result")

--- a/src/framework/cmake/FindCXX11.cmake
+++ b/src/framework/cmake/FindCXX11.cmake
@@ -1,0 +1,26 @@
+if(__FIND_CXX11_CMAKE__)
+    return()
+endif()
+set(__FIND_CXX11_CMAKE__ TRUE)
+
+include(CheckCXXCompilerFlag)
+enable_language(CXX)
+
+check_cxx_compiler_flag("-std=c++11" COMPILER_KNOWS_CXX11)
+if(COMPILER_KNOWS_CXX11)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+
+    # Tested on Mac OS X 10.8.2 with XCode 4.6 Command Line Tools
+    # Clang requires this to find the correct c++11 headers
+    check_cxx_compiler_flag("-stdlib=libc++" COMPILER_KNOWS_STDLIB)
+    if(APPLE AND COMPILER_KNOWS_STDLIB)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+    endif()
+else()
+    check_cxx_compiler_flag("-std=c++0x" COMPILER_KNOWS_CXX0X)
+    if(COMPILER_KNOWS_CXX0X)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
+    else()
+        message(FATAL_ERROR "Your C++ compiler does not support C++11.")
+    endif()
+endif()


### PR DESCRIPTION
The test performed to check for c++11 is not reliable: it breaks without notice and uses a deprecated flag (most compilers now use `c++11` instead of `c++0x`).

This will make CMake fail prior to compiling with a message. Also it enables to compile with Clang, since it requires `-stdlib=libc++`.