### PR TITLE
Some possible Fixes when compiling on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ if(WIN32)
                        -i${CMAKE_CURRENT_SOURCE_DIR}/src/otcicon.rc
                        -o ${CMAKE_CURRENT_BINARY_DIR}/otcicon.o)
     set(executable_SOURCES ${executable_SOURCES} otcicon.o)
+    set(CMAKE_CXX_LINK_FLAGS "-U__STRICT_ANSI__")
 endif()
 
 add_definitions(-D"VERSION=\\"${VERSION}\\"")

--- a/src/framework/platform/platformwindow.cpp
+++ b/src/framework/platform/platformwindow.cpp
@@ -22,7 +22,7 @@
 
 #include "platformwindow.h"
 
-#ifdef WIN32
+#ifdef __WIN32__
 #include "win32window.h"
 WIN32Window window;
 #else

--- a/src/framework/platform/platformwindow.cpp
+++ b/src/framework/platform/platformwindow.cpp
@@ -22,7 +22,7 @@
 
 #include "platformwindow.h"
 
-#ifdef __WIN32__
+#ifdef _WIN32
 #include "win32window.h"
 WIN32Window window;
 #else

--- a/src/framework/platform/unixcrashhandler.cpp
+++ b/src/framework/platform/unixcrashhandler.cpp
@@ -20,7 +20,7 @@
  * THE SOFTWARE.
  */
 
-#if !defined(WIN32) && defined(CRASH_HANDLER)
+#if !defined(__WIN32__) && defined(CRASH_HANDLER)
 
 #include "crashhandler.h"
 #include <framework/global.h>

--- a/src/framework/platform/unixcrashhandler.cpp
+++ b/src/framework/platform/unixcrashhandler.cpp
@@ -20,7 +20,7 @@
  * THE SOFTWARE.
  */
 
-#if !defined(__WIN32__) && defined(CRASH_HANDLER)
+#if !defined(_WIN32) && defined(CRASH_HANDLER)
 
 #include "crashhandler.h"
 #include <framework/global.h>

--- a/src/framework/platform/unixplatform.cpp
+++ b/src/framework/platform/unixplatform.cpp
@@ -20,7 +20,7 @@
  * THE SOFTWARE.
  */
 
-#ifndef WIN32
+#ifndef __WIN32__
 
 #include "platform.h"
 #include <fstream>

--- a/src/framework/platform/unixplatform.cpp
+++ b/src/framework/platform/unixplatform.cpp
@@ -20,7 +20,7 @@
  * THE SOFTWARE.
  */
 
-#ifndef __WIN32__
+#ifndef _WIN32
 
 #include "platform.h"
 #include <fstream>

--- a/src/framework/platform/x11window.cpp
+++ b/src/framework/platform/x11window.cpp
@@ -20,7 +20,7 @@
  * THE SOFTWARE.
  */
 
-#ifndef WIN32
+#ifndef __WIN32__
 
 #include "x11window.h"
 #include <framework/core/resourcemanager.h>

--- a/src/framework/platform/x11window.cpp
+++ b/src/framework/platform/x11window.cpp
@@ -20,7 +20,7 @@
  * THE SOFTWARE.
  */
 
-#ifndef __WIN32__
+#ifndef _WIN32
 
 #include "x11window.h"
 #include <framework/core/resourcemanager.h>


### PR DESCRIPTION
Some possible fixes when compiling on Windows, such as using **WIN32** and using -U__STRICT_ANSI__ because of Boost on MinGW.

I had other problems dealing with MinGW and Codeblocks, but those solutions solved some major compiling problems.
