### PR TITLE
Fix to receive the vocation id from the server protocolgameparse.cpp

### DIFF
--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -1305,9 +1305,9 @@ void ProtocolGame::parsePremiumTrigger(const InputMessagePtr& msg)
 void ProtocolGame::parsePlayerInfo(const InputMessagePtr& msg)
 {
     bool premium = msg->getU8(); // premium
-    int vocation = msg->getU8(); // vocation
     if(g_game.getFeature(Otc::GamePremiumExpiration))
         int premiumEx = msg->getU32(); // premium expiration used for premium advertisement
+    int vocation = msg->getU8(); // vocation
 
     int spellCount = msg->getU16();
     std::vector<int> spells;


### PR DESCRIPTION
The vocation id was not being received by the client.
https://github.com/otland/forgottenserver/issues/1982