### PR TITLE
Fix misleading indentation

### DIFF
--- a/src/framework/util/matrix.h
+++ b/src/framework/util/matrix.h
@@ -193,7 +193,7 @@ std::istream& operator>>(std::istream& in, Matrix<N,M,T>& mat)
     for(int i=0;i<N;++i)
         for(int j=0;j<M;++j)
             in >> mat(i,j);
-        return in;
+    return in;
 }
 
 // faster comparing for 3x3 matrixes


### PR DESCRIPTION
This line creates a ton of warnings on a newer version of GCC since the header is included almost everywhere.