### PR TITLE
Fixed problem with function "useWith" on creatures

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -856,7 +856,10 @@ void Game::useWith(const ItemPtr& item, const ThingPtr& toThing)
     if(!pos.isValid()) // virtual item
         pos = Position(0xFFFF, 0, 0); // means that is an item in inventory
 
-    m_protocolGame->sendUseItemWith(pos, item->getId(), item->getStackPos(), toThing->getPosition(), toThing->getId(), toThing->getStackPos());
+    if(toThing->isCreature())
+        m_protocolGame->sendUseOnCreature(pos, item->getId(), item->getStackPos(), toThing->getId());
+    else
+        m_protocolGame->sendUseItemWith(pos, item->getId(), item->getStackPos(), toThing->getPosition(), toThing->getId(), toThing->getStackPos());
 }
 
 void Game::useInventoryItemWith(int itemId, const ThingPtr& toThing)


### PR DESCRIPTION
Fixed problems with selecting moving monsters in battle list.
Fixed problems with using hotkeys item on creatures (protocol < 780).

Answer to issues:
[#856](https://github.com/edubart/otclient/issues/856)
[#697](https://github.com/edubart/otclient/issues/697)

Threads with this problem on OTLand:
[Problem with Battle - Monsters.](https://otland.net/threads/problem-with-battle-monsters.247449/)
[Can only use this rune on creatures [Bug?]](https://otland.net/threads/can-only-use-this-rune-on-creatures-bug.239093/)