### PR TITLE
[Probable bug] Double use function onAppear

### DIFF
--- a/src/client/map.cpp
+++ b/src/client/map.cpp
@@ -116,7 +116,6 @@ void Map::addThing(const ThingPtr& thing, const Position& pos, int stackPos)
     } else {
         if(thing->isMissile()) {
             m_floorMissiles[pos.z].push_back(thing->static_self_cast<Missile>());
-            thing->onAppear();
         } else if(thing->isAnimatedText()) {
             // this code will stack animated texts of the same color
             AnimatedTextPtr animatedText = thing->static_self_cast<AnimatedText>();


### PR DESCRIPTION
Method Map::addThing uses two times function onAppear for object Missile.
First used in line 119, but then used again the same function in line 165.
Without first function onAppear method Map::addThing work the same.