### PR TITLE
Add setPathable() function

### DIFF
--- a/src/client/luafunctions.cpp
+++ b/src/client/luafunctions.cpp
@@ -526,6 +526,7 @@ void Client::registerLuaFunctions()
     g_lua.bindClassMemberFunction<ThingType>("isNotMoveable", &ThingType::isNotMoveable);
     g_lua.bindClassMemberFunction<ThingType>("blockProjectile", &ThingType::blockProjectile);
     g_lua.bindClassMemberFunction<ThingType>("isNotPathable", &ThingType::isNotPathable);
+    g_lua.bindClassMemberFunction<ThingType>("setPathable", &ThingType::setPathable);
     g_lua.bindClassMemberFunction<ThingType>("isPickupable", &ThingType::isPickupable);
     g_lua.bindClassMemberFunction<ThingType>("isHangable", &ThingType::isHangable);
     g_lua.bindClassMemberFunction<ThingType>("isHookSouth", &ThingType::isHookSouth);

--- a/src/client/thingtype.cpp
+++ b/src/client/thingtype.cpp
@@ -564,3 +564,11 @@ int ThingType::getExactSize(int layer, int xPattern, int yPattern, int zPattern,
     Size size = m_texturesFramesOriginRects[animationPhase][frameIndex].size() - m_texturesFramesOffsets[animationPhase][frameIndex].toSize();
     return std::max<int>(size.width(), size.height());
 }
+
+void ThingType::setPathable(bool var)
+{
+    if(var == true)
+        m_attribs.remove(ThingAttrNotPathable);
+    else
+        m_attribs.set(ThingAttrNotPathable, true);
+}

--- a/src/client/thingtype.h
+++ b/src/client/thingtype.h
@@ -178,7 +178,7 @@ public:
     bool isNotMoveable() { return m_attribs.has(ThingAttrNotMoveable); }
     bool blockProjectile() { return m_attribs.has(ThingAttrBlockProjectile); }
     bool isNotPathable() { return m_attribs.has(ThingAttrNotPathable); }
-	void setPathable(bool var) { var == true ? m_attribs.remove(ThingAttrNotPathable) : m_attribs.set(ThingAttrNotPathable, true); }
+	void setPathable(bool var);
     bool isPickupable() { return m_attribs.has(ThingAttrPickupable); }
     bool isHangable() { return m_attribs.has(ThingAttrHangable); }
     bool isHookSouth() { return m_attribs.has(ThingAttrHookSouth); }

--- a/src/client/thingtype.h
+++ b/src/client/thingtype.h
@@ -178,7 +178,6 @@ public:
     bool isNotMoveable() { return m_attribs.has(ThingAttrNotMoveable); }
     bool blockProjectile() { return m_attribs.has(ThingAttrBlockProjectile); }
     bool isNotPathable() { return m_attribs.has(ThingAttrNotPathable); }
-	void setPathable(bool var);
     bool isPickupable() { return m_attribs.has(ThingAttrPickupable); }
     bool isHangable() { return m_attribs.has(ThingAttrHangable); }
     bool isHookSouth() { return m_attribs.has(ThingAttrHookSouth); }
@@ -207,6 +206,7 @@ public:
     // additional
     float getOpacity() { return m_opacity; }
     bool isNotPreWalkable() { return m_attribs.has(ThingAttrNotPreWalkable); }
+    void setPathable(bool var);
 
 private:
     const TexturePtr& getTexture(int animationPhase);

--- a/src/client/thingtype.h
+++ b/src/client/thingtype.h
@@ -178,6 +178,7 @@ public:
     bool isNotMoveable() { return m_attribs.has(ThingAttrNotMoveable); }
     bool blockProjectile() { return m_attribs.has(ThingAttrBlockProjectile); }
     bool isNotPathable() { return m_attribs.has(ThingAttrNotPathable); }
+	void setPathable(bool var) { var == true ? m_attribs.remove(ThingAttrNotPathable) : m_attribs.set(ThingAttrNotPathable, true); }
     bool isPickupable() { return m_attribs.has(ThingAttrPickupable); }
     bool isHangable() { return m_attribs.has(ThingAttrHangable); }
     bool isHookSouth() { return m_attribs.has(ThingAttrHookSouth); }


### PR DESCRIPTION
Adding function who changing item attribute (ThingAttrNotPathable).
Allows to walk on not pathable items (ThingAttrNotPathable -> true) like parcels, fire fields etc. and vice versa.
Modifying item attribute without editing items sources files. Temporary action for the duration of the client session.

Usage:
```
print(g_things.getThingType(3504):isNotPathable()) -> true

g_things.getThingType(3504):setPathable(true)

print(g_things.getThingType(3504):isNotPathable()) -> false
```

Helpful for highter levels players to ignoring "avoiding" fire/energy/poison fields etc. when using map click.