### PR TITLE
Add a keyboard shortcut to toggle topmenu visibility

### DIFF
--- a/modules/client_topmenu/topmenu.lua
+++ b/modules/client_topmenu/topmenu.lua
@@ -51,6 +51,8 @@ function init()
   pingLabel = topMenu:getChildById('pingLabel')
   fpsLabel = topMenu:getChildById('fpsLabel')
 
+  g_keyboard.bindKeyDown('Ctrl+Shift+T', toggle)
+
   if g_game.isOnline() then
     online()
   end
@@ -163,4 +165,21 @@ end
 
 function getTopMenu()
   return topMenu
+end
+
+function toggle()
+  local menu = getTopMenu()
+  if not menu then
+    return
+  end
+
+  if menu:isVisible() then
+    menu:hide()
+    modules.client_background.getBackground():addAnchor(AnchorTop, 'parent', AnchorTop)
+    modules.game_interface.getRootPanel():addAnchor(AnchorTop, 'parent', AnchorTop)
+  else
+    menu:show()
+    modules.client_background.getBackground():addAnchor(AnchorTop, 'topMenu', AnchorBottom)
+    modules.game_interface.getRootPanel():addAnchor(AnchorTop, 'topMenu', AnchorBottom)
+  end
 end

--- a/modules/client_topmenu/topmenu.lua
+++ b/modules/client_topmenu/topmenu.lua
@@ -177,9 +177,11 @@ function toggle()
     menu:hide()
     modules.client_background.getBackground():addAnchor(AnchorTop, 'parent', AnchorTop)
     modules.game_interface.getRootPanel():addAnchor(AnchorTop, 'parent', AnchorTop)
+    modules.game_interface.getShowTopMenuButton():show()
   else
     menu:show()
     modules.client_background.getBackground():addAnchor(AnchorTop, 'topMenu', AnchorBottom)
     modules.game_interface.getRootPanel():addAnchor(AnchorTop, 'topMenu', AnchorBottom)
+    modules.game_interface.getShowTopMenuButton():hide()
   end
 end

--- a/modules/game_interface/gameinterface.lua
+++ b/modules/game_interface/gameinterface.lua
@@ -5,6 +5,7 @@ gameMapPanel = nil
 gameRightPanel = nil
 gameLeftPanel = nil
 gameBottomPanel = nil
+showTopMenuButton = nil
 logoutButton = nil
 mouseGrabberWidget = nil
 countWindow = nil
@@ -54,6 +55,11 @@ function init()
 
   logoutButton = modules.client_topmenu.addLeftButton('logoutButton', tr('Exit'),
     '/images/topbuttons/logout', tryLogout, true)
+
+  showTopMenuButton = gameMapPanel:getChildById('showTopMenuButton')
+  showTopMenuButton.onClick = function()
+    modules.client_topmenu.toggle()
+  end
 
   setupViewMode(0)
 
@@ -798,6 +804,10 @@ end
 
 function getBottomPanel()
   return gameBottomPanel
+end
+
+function getShowTopMenuButton()
+  return showTopMenuButton
 end
 
 function onLeftPanelVisibilityChange(leftPanel, visible)

--- a/modules/game_interface/gameinterface.otui
+++ b/modules/game_interface/gameinterface.otui
@@ -32,6 +32,14 @@ UIWidget
     anchors.bottom: gameBottomPanel.top
     focusable: false
 
+    Button
+      id: showTopMenuButton
+      anchors.top: parent.top
+      anchors.left: parent.left
+      !text: tr('Show Top Menu')
+      height: 32
+      visible: false
+
   GameBottomPanel
     id: gameBottomPanel
     anchors.left: gameLeftPanel.right

--- a/modules/game_interface/gameinterface.otui
+++ b/modules/game_interface/gameinterface.otui
@@ -1,4 +1,3 @@
-
 GameSidePanel < UIMiniWindowContainer
   image-source: /images/ui/panel_side
   image-border: 4


### PR DESCRIPTION
This PR adds a shortcut (Ctrl-Shift-T) that lets you toggle the top menu visibility to save some vertical space.