### PR TITLE
Fix game interface not gaining focus after exitting the market

### DIFF
--- a/modules/game_market/market.lua
+++ b/modules/game_market/market.lua
@@ -990,6 +990,7 @@ function Market.close(notify)
   if not marketWindow:isHidden() then
     marketWindow:hide()
     marketWindow:unlock()
+    modules.game_interface.getRootPanel():focus()
     Market.clearSelectedItem()
     Market.reset()
     if notify then


### PR DESCRIPTION
This addresses #869. It happens because the market window is always present, just hidden when it's not active, rather than being destroyed and passing the focus back.