### PR TITLE
Add turn and hotkey delay

### DIFF
--- a/modules/client_options/game.otui
+++ b/modules/client_options/game.otui
@@ -38,11 +38,51 @@ Panel
     id: displayText
     !text: tr('Display text messages')
 
+  Label
+    id: turnDelayLabel
+    !text: tr('Turn delay: %sms', 30)
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.top: prev.bottom
+    margin-top: 12
+    @onSetup: |
+      local value = modules.client_options.getOption('turnDelay')
+      self:setText(tr('Turn delay: %dms', value))
+
+  OptionScrollbar
+    id: turnDelay
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.top: prev.bottom
+    margin-top: 3
+    minimum: 30
+    maximum: 250
+
+  Label
+    id: hotkeyDelayLabel
+    !text: tr('Hotkey delay: %dms', 30)
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.top: prev.bottom
+    margin-top: 12
+    @onSetup: |
+      local value = modules.client_options.getOption('hotkeyDelay')
+      self:setText(tr('Hotkey delay: %dms', value))
+
+  OptionScrollbar
+    id: hotkeyDelay
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.top: prev.bottom
+    margin-top: 3
+    minimum: 30
+    maximum: 250
+
   Button
     id: changeLocale
     !text: tr('Change language')
     @onClick: modules.client_locales.createWindow()
     anchors.top: prev.bottom
     anchors.left: prev.left
-    margin-top: 5
+    margin-top: 12
     width: 120

--- a/modules/client_options/options.lua
+++ b/modules/client_options/options.lua
@@ -26,7 +26,9 @@ local defaultOptions = {
   displayNames = true,
   displayHealth = true,
   displayText = true,
-  dontStretchShrink = false
+  dontStretchShrink = false,
+  turnDelay = 50,
+  hotkeyDelay = 50,
 }
 
 local optionsWindow
@@ -228,6 +230,10 @@ function setOption(key, value, force)
     addEvent(function()
       modules.game_interface.updateStretchShrink()
     end)
+  elseif key == 'turnDelay' then
+    generalPanel:getChildById('turnDelayLabel'):setText(tr('Turn delay: %sms', value))
+  elseif key == 'hotkeyDelay' then
+    generalPanel:getChildById('hotkeyDelayLabel'):setText(tr('Hotkey delay: %sms', value))
   end
 
   -- change value for keybind updates

--- a/modules/game_hotkeys/hotkeys_manager.lua
+++ b/modules/game_hotkeys/hotkeys_manager.lua
@@ -36,6 +36,7 @@ useRadioGroup = nil
 currentHotkeys = nil
 boundCombosCallback = {}
 hotkeysList = {}
+lastHotkeyTime = g_clock.millis()
 
 -- public functions
 function init()
@@ -374,6 +375,12 @@ function doKeyCombo(keyCombo)
   if not g_game.isOnline() then return end
   local hotKey = hotkeyList[keyCombo]
   if not hotKey then return end
+
+  if g_clock.millis() - lastHotkeyTime < modules.client_options.getOption('hotkeyDelay') then
+    return
+  end
+  lastHotkeyTime = g_clock.millis()
+
   if hotKey.itemId == nil then
     if not hotKey.value or #hotKey.value == 0 then return end
     if hotKey.autoSend then

--- a/modules/game_interface/gameinterface.lua
+++ b/modules/game_interface/gameinterface.lua
@@ -17,6 +17,7 @@ smartWalkDirs = {}
 smartWalkDir = nil
 walkFunction = nil
 hookedMenuOptions = {}
+lastDirTime = g_clock.millis()
 
 function init()
   g_ui.importStyle('styles/countwindow')
@@ -80,14 +81,15 @@ function bindKeys()
   bindWalkKey('Numpad4', West)
   bindWalkKey('Numpad7', NorthWest)
 
-  g_keyboard.bindKeyPress('Ctrl+Up', function() g_game.turn(North) changeWalkDir(North) end, gameRootPanel)
-  g_keyboard.bindKeyPress('Ctrl+Right', function() g_game.turn(East) changeWalkDir(East) end, gameRootPanel)
-  g_keyboard.bindKeyPress('Ctrl+Down', function() g_game.turn(South) changeWalkDir(South) end, gameRootPanel)
-  g_keyboard.bindKeyPress('Ctrl+Left', function() g_game.turn(West) changeWalkDir(West) end, gameRootPanel)
-  g_keyboard.bindKeyPress('Ctrl+Numpad8', function() g_game.turn(North) changeWalkDir(North) end, gameRootPanel)
-  g_keyboard.bindKeyPress('Ctrl+Numpad6', function() g_game.turn(East) changeWalkDir(East) end, gameRootPanel)
-  g_keyboard.bindKeyPress('Ctrl+Numpad2', function() g_game.turn(South) changeWalkDir(South) end, gameRootPanel)
-  g_keyboard.bindKeyPress('Ctrl+Numpad4', function() g_game.turn(West) changeWalkDir(West) end, gameRootPanel)
+  bindTurnKey('Ctrl+Up', North)
+  bindTurnKey('Ctrl+Right', East)
+  bindTurnKey('Ctrl+Down', South)
+  bindTurnKey('Ctrl+Left', West)
+  bindTurnKey('Ctrl+Numpad8', North)
+  bindTurnKey('Ctrl+Numpad6', East)
+  bindTurnKey('Ctrl+Numpad2', South)
+  bindTurnKey('Ctrl+Numpad4', West)
+
   g_keyboard.bindKeyPress('Escape', function() g_game.cancelAttackAndFollow() end, gameRootPanel)
   g_keyboard.bindKeyPress('Ctrl+=', function() gameMapPanel:zoomIn() end, gameRootPanel)
   g_keyboard.bindKeyPress('Ctrl+-', function() gameMapPanel:zoomOut() end, gameRootPanel)
@@ -107,6 +109,19 @@ function unbindWalkKey(key)
   g_keyboard.unbindKeyDown(key, gameRootPanel)
   g_keyboard.unbindKeyUp(key, gameRootPanel)
   g_keyboard.unbindKeyPress(key, gameRootPanel)
+end
+
+function bindTurnKey(key, dir)
+  local function callback(widget, code, repeatTicks)
+    if g_clock.millis() - lastDirTime >= modules.client_options.getOption('turnDelay') then
+        g_game.turn(dir)
+        changeWalkDir(dir)
+
+        lastDirTime = g_clock.millis()
+    end
+  end
+
+  g_keyboard.bindKeyPress(key, callback, gameRootPanel)
 end
 
 function terminate()


### PR DESCRIPTION
This partially addresses #903 and #564.

I don't think limiting the packet rate is a good solution since the behavior could be desired in many actions and would otherwise make the client feel clunky but since hotkey actions are sent at the rate of foreground FPS this should address the issue where too many actions are being sent by turn and hotkey keys.

The delay can be configured through Options -> Game settings panel.