### PR TITLE
Update OTClient outdated version in VS project

### DIFF
--- a/vc14/settings.props
+++ b/vc14/settings.props
@@ -25,7 +25,7 @@
         BUILD_TYPE="RelWithDebInfo";
         BUILD_COMMIT="devel";
         BUILD_REVISION="0";
-        VERSION="0.6.3";
+        VERSION="0.6.6";
         AB
     </PREPROCESSOR_DEFS>
     


### PR DESCRIPTION
Change OTClient version from 0.6.3 to 0.6.6 in Visual Studio project.