### PR TITLE
Add compiler info to version label in start screen

### DIFF
--- a/modules/client_background/background.lua
+++ b/modules/client_background/background.lua
@@ -10,7 +10,7 @@ function init()
   clientVersionLabel = background:getChildById('clientVersionLabel')
   clientVersionLabel:setText(g_app.getName() .. ' ' .. g_app.getVersion() .. '\n' ..
                              'Rev  ' .. g_app.getBuildRevision() .. ' ('.. g_app.getBuildCommit() .. ')\n' ..
-                             'Built on ' .. g_app.getBuildDate())
+                             'Built on ' .. g_app.getBuildDate() .. '\n' .. g_app.getBuildCompiler())
 
   if not g_game.isOnline() then
     addEvent(function() g_effects.fadeIn(clientVersionLabel, 1500) end)


### PR DESCRIPTION
Add compiler name and version to start screen (client_background module).
It would help distinguish OTClient problems on different compilations.
![bck_mod_version_label](https://user-images.githubusercontent.com/29635365/33350333-7d66b8c0-d49e-11e7-9b9e-a395b9d14ff2.png)
