### PR TITLE
UIMiniWindowContainer small improve

### DIFF
--- a/modules/corelib/ui/uiminiwindow.lua
+++ b/modules/corelib/ui/uiminiwindow.lua
@@ -3,6 +3,7 @@ UIMiniWindow = extends(UIWindow, "UIMiniWindow")
 
 function UIMiniWindow.create()
   local miniwindow = UIMiniWindow.internalCreate()
+  miniwindow.UIMiniWindowContainer = true
   return miniwindow
 end
 

--- a/modules/corelib/ui/uiminiwindowcontainer.lua
+++ b/modules/corelib/ui/uiminiwindowcontainer.lua
@@ -83,7 +83,7 @@ function UIMiniWindowContainer:fitAll(noRemoveChild)
 end
 
 function UIMiniWindowContainer:onDrop(widget, mousePos)
-  if widget:getClassName() == 'UIMiniWindow' then
+  if widget.UIMiniWindowContainer then
     local oldParent = widget:getParent()
     if oldParent == self then
       return true


### PR DESCRIPTION
Change type of checking whether window have on drop possibility.

Reason:
Previously this parameter was checking by class name, so it blocking creating similar objects to miniwindow or inheritance from miniwindow object without changing sources. So it block creating modules with new UI objects working with miniwindowcontainer.

Additional feature:
Flag set to false has blocking dropping miniwindow in right/left panel.
So it provide to use miniwindow in other tasks.