### PR TITLE
Fix vertical tooltip clamping

### DIFF
--- a/modules/corelib/ui/tooltip.lua
+++ b/modules/corelib/ui/tooltip.lua
@@ -10,13 +10,24 @@ local function moveToolTip(first)
   if not first and (not toolTipLabel:isVisible() or toolTipLabel:getOpacity() < 0.1) then return end
 
   local pos = g_window.getMousePosition()
+  local windowSize = g_window.getSize()
+  local labelSize = toolTipLabel:getSize()
+
+  pos.x = pos.x + 1
   pos.y = pos.y + 1
-  local xdif = g_window.getSize().width - (pos.x + toolTipLabel:getWidth())
-  if xdif < 10 then
-    pos.x = pos.x - toolTipLabel:getWidth() - 3
+
+  if windowSize.width - (pos.x + labelSize.width) < 10 then
+    pos.x = pos.x - labelSize.width - 3
   else
     pos.x = pos.x + 10
   end
+
+  if windowSize.height - (pos.y + labelSize.height) < 10 then
+    pos.y = pos.y - labelSize.height - 3
+  else
+    pos.y = pos.y + 10
+  end
+
   toolTipLabel:setPosition(pos)
 end
 


### PR DESCRIPTION
This just expands upon the horizontal tooltip behavior where the tooltip is offset so that it stays within the screen bounds. Now it works across both axes.