### PR TITLE
Fix write dir missing a trailing slash

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -22,7 +22,7 @@ end
 g_resources.addSearchPath(g_resources.getWorkDir() .. "mods", true)
 
 -- setup directory for saving configurations
-g_resources.setupUserWriteDir(g_app.getCompactName())
+g_resources.setupUserWriteDir(('%s/'):format(g_app.getCompactName()))
 
 -- search all packages
 g_resources.searchAndAddPackages('/', '.otpkg', true)


### PR DESCRIPTION
Newer PhysFS version requires a trailing slash for the write directory, otherwise an empty file is created instead.
Older versions should remain unaffected.

This fixes https://github.com/edubart/otclient/issues/468#issuecomment-36684359.