### PR TITLE
Fix problem with display text in setupViewMode_2

### DIFF
--- a/modules/game_textmessage/textmessage.otui
+++ b/modules/game_textmessage/textmessage.otui
@@ -8,7 +8,7 @@ TextMessageLabel < UILabel
 
 Panel
   anchors.fill: gameMapPanel
-  anchors.bottom: gameBottomPanel.top
+  anchors.bottom: gameMapPanel.bottom
   focusable: false
 
   Panel


### PR DESCRIPTION
Fix problem with display text messages in setupViewMode - 2 ([CTRL + .] x 2).
Status messages was display in other place (higher than player character).

Problem:
![viewmode_2_problem](https://user-images.githubusercontent.com/29635365/36970935-1f0444e0-2062-11e8-827f-4dd5821f1bb7.png)

Fix:
![viewmode_2_fixed](https://user-images.githubusercontent.com/29635365/36970955-2b5631ea-2062-11e8-89e4-a2d341065e58.png)
