### PR TITLE
Fix tab blink

### DIFF
--- a/modules/corelib/ui/uimovabletabbar.lua
+++ b/modules/corelib/ui/uimovabletabbar.lua
@@ -385,6 +385,11 @@ function UIMoveableTabBar:selectTab(tab)
   tab:setOn(false)
   tab.blinking = false
 
+  if tab.blinkEvent then
+    removeEvent(tab.blinkEvent)
+    tab.blinkEvent = nil
+  end
+
   local parent = tab:getParent()
   parent:focusChild(tab, MouseFocusReason)
   updateNavigation(self)


### PR DESCRIPTION
The event should be removed when selecting a tab, otherwise when you select a blinking tab and then deselect it, it will remain in the urgent state.