### PR TITLE
Silence Windows SDK warnings when building with MSVC

### DIFF
--- a/src/framework/platform/win32crashhandler.cpp
+++ b/src/framework/platform/win32crashhandler.cpp
@@ -29,7 +29,19 @@
 #include <winsock2.h>
 #include <windows.h>
 #include <process.h>
+
+#ifdef _MSC_VER
+
+#pragma warning (push)
+#pragma warning (disable:4091) // warning C4091: 'typedef ': ignored on left of '' when no variable is declared
 #include <imagehlp.h>
+#pragma warning (pop)
+
+#else
+
+#include <imagehlp.h>
+
+#endif
 
 const char *getExceptionName(DWORD exceptionCode)
 {

--- a/src/framework/stdext/demangle.cpp
+++ b/src/framework/stdext/demangle.cpp
@@ -23,13 +23,21 @@
 #include "demangle.h"
 
 #ifdef _MSC_VER
+
 #include <winsock2.h>
 #include <windows.h>
+
+#pragma warning (push)
+#pragma warning (disable:4091) // warning C4091: 'typedef ': ignored on left of '' when no variable is declared
 #include <dbghelp.h>
+#pragma warning (pop)
+
 #else
+
 #include <cxxabi.h>
 #include <cstring>
 #include <cstdlib>
+
 #endif
 
 namespace stdext {


### PR DESCRIPTION
When building otclient using MSVC with specific Windows SDK versions, it produces warnings related to the imagehlp.h and dbghelp.h SDK headers. Since this is an error on Microsoft's part and there's nothing we can do to fix these in otclient, I figured we might as well silence the warnings for these two headers to filter out this random noise from the build log.