### PR TITLE
Add -no-pie option to CMAKE_CXX_LINK_FLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ include(src/client/CMakeLists.txt)
 
 # functions map for reading backtraces
 if(NOT APPLE)
-    set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -Wl,-Map=${PROJECT_NAME}.map")
+    set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -no-pie -Wl,-Map=${PROJECT_NAME}.map")
 endif()
 
 option(USE_PCH "Use precompiled header (speed up compile)" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ include(src/client/CMakeLists.txt)
 
 # functions map for reading backtraces
 if(NOT APPLE)
-    set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -no-pie -Wl,-Map=${PROJECT_NAME}.map")
+    set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -no-pie, -Wl,-Map=${PROJECT_NAME}.map")
 endif()
 
 option(USE_PCH "Use precompiled header (speed up compile)" OFF)


### PR DESCRIPTION
Fixes compiling issues with libogg in Mint Linux 19
----
This is the error I've encountered compiling otclient in Mint Linux 19 without this option
```
/usr/bin/x86_64-linux-gnu-ld: /usr/lib/gcc/x86_64-linux-gnu/7/../../../x86_64-linux-gnu/libogg.a(framing.o): relocation R_X86_64_32S against `.rodata' can not be used when making a PIE object; recompile with -fPIC
```