### PR TITLE
Show more information in stamina bar

### DIFF
--- a/modules/game_skills/skills.lua
+++ b/modules/game_skills/skills.lua
@@ -120,7 +120,7 @@ function setSkillTooltip(id, value)
   widget:setTooltip(value)
 end
 
-function setSkillPercent(id, percent, tooltip)
+function setSkillPercent(id, percent, tooltip, color)
   local skill = skillsWindow:recursiveGetChildById(id)
   local widget = skill:getChildById('percent')
   if widget then
@@ -128,6 +128,10 @@ function setSkillPercent(id, percent, tooltip)
 
     if tooltip then
       widget:setTooltip(tooltip)
+    end
+
+    if color then
+    	widget:setBackgroundColor(color)
     end
   end
 end
@@ -333,10 +337,34 @@ function onStaminaChange(localPlayer, stamina)
   if minutes < 10 then
     minutes = '0' .. minutes
   end
-  local percent = math.floor(100 * stamina / (42 * 60)) -- max is 42 hours
+  local percent = math.floor(100 * stamina / (42 * 60)) -- max is 42 hours --TODO not in all client versions
 
   setSkillValue('stamina', hours .. ":" .. minutes)
-  setSkillPercent('stamina', percent, tr('You have %s percent', percent))
+
+  --TODO not all client versions have premium time
+  if stamina > 2400 and g_game.getClientVersion() >= 1038 and localPlayer:isPremium() then
+  	local text = tr("You have %s hours and %s minutes left", hours, minutes) .. '\n' ..
+		tr("Now you will gain 50%% more experience")
+		setSkillPercent('stamina', percent, text, 'green')
+	elseif stamina > 2400 and g_game.getClientVersion() >= 1038 and not localPlayer:isPremium() then
+		local text = tr("You have %s hours and %s minutes left", hours, minutes) .. '\n' ..
+		tr("You will not gain 50%% more experience because you aren't premium player, now you receive only 1x experience points")
+		setSkillPercent('stamina', percent, text, '#89F013')
+	elseif stamina > 2400 and g_game.getClientVersion() < 1038 then
+		local text = tr("You have %s hours and %s minutes left", hours, minutes) .. '\n' ..
+		tr("If you are premium player, you will gain 50%% more experience")
+		setSkillPercent('stamina', percent, text, 'green')
+	elseif stamina <= 2400 and stamina > 840 then
+		setSkillPercent('stamina', percent, tr("You have %s hours and %s minutes left", hours, minutes), 'orange')
+	elseif stamina <= 840 and stamina > 0 then
+		local text = tr("You have %s hours and %s minutes left", hours, minutes) .. "\n" ..
+		tr("You gain only 50%% experience and you don't may gain loot from monsters")
+		setSkillPercent('stamina', percent, text, 'red')
+	elseif stamina == 0 then
+		local text = tr("You have %s hours and %s minutes left", hours, minutes) .. "\n" ..
+		tr("You don't may receive experience and loot from monsters")
+		setSkillPercent('stamina', percent, text, 'black')
+	end
 end
 
 function onOfflineTrainingChange(localPlayer, offlineTrainingTime)


### PR DESCRIPTION
1. Change colors on certain values, when stamina time was change.
2. Change tooltip on certain values, when stamina time was change.
3. Work with most protocols, including the most popular (8.54 - 10.98).
4. In protocols >= 1031 use information about premium account to show if player have premium stamina time.

Fix #989 
Stamina info from: https://github.com/otland/forgottenserver/blob/5438d50b35bc531f35eb188a1e51ccf17af5ebb7/data/events/scripts/player.lua#L254-L259