### PR TITLE
Fix an issue with key combo desc not working properly with integer keys

### DIFF
--- a/modules/corelib/keyboard.lua
+++ b/modules/corelib/keyboard.lua
@@ -26,6 +26,11 @@ local function retranslateKeyComboDesc(keyComboDesc)
   if keyComboDesc == nil then
     error('Unable to translate key combo \'' .. keyComboDesc .. '\'')
   end
+
+  if type(keyComboDesc) == 'number' then
+    keyComboDesc = tostring(keyComboDesc)
+  end
+
   local keyCombo = {}
   for i,currentKeyDesc in ipairs(keyComboDesc:split('+')) do
     for keyCode, keyDesc in pairs(KeyCodeDescs) do


### PR DESCRIPTION
This can occur when restoring widget keyboard bindings from a config file as saving strings containing only digits will turn them into a number value when reading back from OTML.