### PR TITLE
Fix saving ignore list and whitelist

### DIFF
--- a/modules/game_console/console.lua
+++ b/modules/game_console/console.lua
@@ -1202,15 +1202,15 @@ function loadCommunicationSettings()
 
   local ignoreNode = g_settings.getNode('IgnorePlayers')
   if ignoreNode then
-    for i = 1, #ignoreNode do
-      table.insert(communicationSettings.ignoredPlayers, ignoreNode[i])
+    for _, player in pairs(ignoreNode) do
+      table.insert(communicationSettings.ignoredPlayers, player)
     end
   end
 
   local whitelistNode = g_settings.getNode('WhitelistedPlayers')
   if whitelistNode then
-    for i = 1, #whitelistNode do
-      table.insert(communicationSettings.whitelistedPlayers, whitelistNode[i])
+    for _, player in pairs(whitelistNode) do
+      table.insert(communicationSettings.whitelistedPlayers, player)
     end
   end
 


### PR DESCRIPTION
The OTML nodes are saved in the key: value format where the key is the table index in this case, however reading the values back from OTML turns those number values into string values, rendering #table ineffective. This makes the ignore list and whitelist get properly restored from the config.