### PR TITLE
Improve mouse move event propagation

### DIFF
--- a/src/framework/ui/uimanager.cpp
+++ b/src/framework/ui/uimanager.cpp
@@ -142,6 +142,12 @@ void UIManager::inputEvent(const InputEvent& event)
                     break;
             }
 
+            if(m_pressedWidget) {
+                if(m_pressedWidget->onMouseMove(event.mousePos, event.mouseMoved)) {
+                    break;
+                }
+            }
+
             m_mouseReceiver->propagateOnMouseMove(event.mousePos, event.mouseMoved, widgetList);
             for(const UIWidgetPtr& widget : widgetList) {
                 if(widget->onMouseMove(event.mousePos, event.mouseMoved))

--- a/src/framework/ui/uiwidget.cpp
+++ b/src/framework/ui/uiwidget.cpp
@@ -1712,12 +1712,15 @@ bool UIWidget::propagateOnMouseEvent(const Point& mousePos, UIWidgetList& widget
 
 bool UIWidget::propagateOnMouseMove(const Point& mousePos, const Point& mouseMoved, UIWidgetList& widgetList)
 {
-    for(auto it = m_children.begin(); it != m_children.end(); ++it) {
-        const UIWidgetPtr& child = *it;
-        if(child->isExplicitlyVisible() && child->isExplicitlyEnabled())
-            child->propagateOnMouseMove(mousePos, mouseMoved, widgetList);
+    if(containsPaddingPoint(mousePos)) {
+        for(auto it = m_children.begin(); it != m_children.end(); ++it) {
+            const UIWidgetPtr& child = *it;
+            if(child->isExplicitlyVisible() && child->isExplicitlyEnabled() && child->containsPoint(mousePos))
+                child->propagateOnMouseMove(mousePos, mouseMoved, widgetList);
+
+            widgetList.push_back(static_self_cast<UIWidget>());
+        }
     }
 
-    widgetList.push_back(static_self_cast<UIWidget>());
     return true;
 }


### PR DESCRIPTION
This changes the mouse move event propagation to only send the event to widgets whose rect contains the mouse position. Currently otclient will propagate the event to every single widget on the screen, even those that aren't really interested in the event and it becomes worse the more windows/widgets you have on the screen. In the most pathological case in my client that would be up to 1500~ events per mouse move with the current implementation, down to just about 8~ in the same scenario with the patch.

This is even worse in some std::deque implementations where thousands of allocations and dealloactions for each mouse move would grind the client to a halt (which is what actually prompted me to investigate the issue).

The best way to go about testing this would be running unpatched otclient then moving your mouse quickly around your character and watching the FPS counter drop, then opening as many windows as possible (such as the skills, battle, vip panels and containers), and watching the FPS drop even further, with this patch there should be barely any observable difference.

I'm not entirely sure why it wasn't done this way initially as the mouse press propagation works properly and the only reason I can think of is the scrollbar slider which should react even if you hold it and move the mouse outside of the scrollbar rect however this is trivially fixed by manually propagating the mouse move event to the currently pressed widget (if any) in the UIManager.