### PR TITLE
Fix tooltip position updating

### DIFF
--- a/modules/corelib/ui/tooltip.lua
+++ b/modules/corelib/ui/tooltip.lua
@@ -62,7 +62,6 @@ function g_tooltip.init()
     toolTipLabel:setBackgroundColor('#111111cc')
     toolTipLabel:setTextAlign(AlignCenter)
     toolTipLabel:hide()
-    toolTipLabel.onMouseMove = function() moveToolTip() end
   end)
 end
 
@@ -89,10 +88,18 @@ function g_tooltip.display(text)
   toolTipLabel:enable()
   g_effects.fadeIn(toolTipLabel, 100)
   moveToolTip(true)
+
+  connect(rootWidget, {
+    onMouseMove = moveToolTip,
+  })
 end
 
 function g_tooltip.hide()
   g_effects.fadeOut(toolTipLabel, 100)
+
+  disconnect(rootWidget, {
+    onMouseMove = moveToolTip,
+  })
 end
 
 


### PR DESCRIPTION
This fixes the bug I introduced in #1037. The tooltip position is now updated through the onMouseMove event in the root widget which always receives mouse updates.