### PR TITLE
Add default copy constructors to Color and Position classes

### DIFF
--- a/src/client/position.h
+++ b/src/client/position.h
@@ -36,6 +36,8 @@ public:
     Position() : x(65535), y(65535), z(255) { }
     Position(uint16 x, uint16 y, uint8 z) : x(x), y(y), z(z) { }
 
+    Position(const Position &position) = default;
+
     Position translatedToDirection(Otc::Direction direction) {
         Position pos = *this;
         switch(direction) {

--- a/src/framework/util/color.h
+++ b/src/framework/util/color.h
@@ -39,6 +39,8 @@ public:
     Color(float r, float g, float b, float a = 1.0f) : m_r(r), m_g(g), m_b(b), m_a(a) { }
     Color(const std::string& coltext);
 
+    Color(const Color &color) = default;
+
     uint8 a() const { return m_a*255.0f; }
     uint8 b() const { return m_b*255.0f; }
     uint8 g() const { return m_g*255.0f; }


### PR DESCRIPTION
GCC 9 adds a new diagnostic (-Wdeprecated-copy) that addresses the following:
>The generation of the implicitly-defined copy constructor is deprecated if T has a user-defined destructor or user-defined copy assignment operator. 

This results in dozens of warnings in all files that include the Color and Position classes as those classes supply user-defined copy assignment but no explicit copy constructor.