### PR TITLE
Update Travis build file to use physfs stable 3.0 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_script:
       mercurial \
       zlib1g-dev
 
-    hg clone -r stable-2.0 http://hg.icculus.org/icculus/physfs/
+    hg clone -r stable-3.0 http://hg.icculus.org/icculus/physfs/
     mkdir -p physfs/build
     pushd physfs/build
     cmake ..


### PR DESCRIPTION
This updates the Travis file to pull PhysFS 3 as mentioned in #1044 and #1045.