### PR TITLE
Fix a possible missing null terminator in the demangle_name output buffer

### DIFF
--- a/src/framework/stdext/demangle.cpp
+++ b/src/framework/stdext/demangle.cpp
@@ -45,21 +45,25 @@ namespace stdext {
 const char* demangle_name(const char* name)
 {
     static const unsigned BufferSize = 1024;
-    static char Buffer[1024] = {};
+    static char Buffer[BufferSize] = {};
 
 #ifdef _MSC_VER
-    UnDecorateSymbolName(name, Buffer, BufferSize, UNDNAME_COMPLETE);
-    return Buffer;
+    int written = UnDecorateSymbolName(name, Buffer, BufferSize - 1, UNDNAME_COMPLETE);
+    Buffer[written] = '\0';
 #else
     size_t len;
     int status;
     char* demangled = abi::__cxa_demangle(name, nullptr, &len, &status);
     if(demangled) {
-        strncpy(Buffer, demangled, BufferSize);
+        strncpy(Buffer, demangled, BufferSize - 1);
+        Buffer[BufferSize - 1] = '\0';
         free(demangled);
+    } else {
+        Buffer[0] = '\0';
     }
-    return Buffer;
 #endif
+
+    return Buffer;
 }
 
 }


### PR DESCRIPTION
In #1044 I had introduced a subtle bug where the demangled symbol name buffer could end up without a null terminator if the length of the demangled symbol name was equal or greater than the buffer size, this fixes the issue.