### PR TITLE
fix initial language selection

### DIFF
--- a/modules/client_locales/locales.lua
+++ b/modules/client_locales/locales.lua
@@ -144,7 +144,10 @@ end
 
 function setLocale(name)
   local locale = installedLocales[name]
-  if locale == currentLocale then return end
+  if locale == currentLocale then
+    g_settings.set('locale', name)
+    return
+  end
   if not locale then
     pwarning("Locale " .. name .. ' does not exist.')
     return false


### PR DESCRIPTION
fix language selection bug

steps to reproduce:
- go to c:/users/username/otclient and remove settings file
- launch otclient
- select english
- restart otclient

expected behaviour: no more startup prompts for language selection when selecting default language
observed behaviour: everytime client gets restarted and you click the default language, it doesn't get saved if it didn't exist in config file previously