### PR TITLE
Getting rid of redraw on lying corpse

### DIFF
--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -95,9 +95,6 @@ void Tile::draw(const Point& dest, float scaleFactor, int drawFlags, LightView *
         }
     }
 
-    int redrawPreviousTopW = 0;
-    int redrawPreviousTopH = 0;
-
     if(drawFlags & Otc::DrawItems) {
         // now common items in reverse order
         for(auto it = m_things.rbegin(); it != m_things.rend(); ++it) {
@@ -105,31 +102,9 @@ void Tile::draw(const Point& dest, float scaleFactor, int drawFlags, LightView *
             if(thing->isOnTop() || thing->isOnBottom() || thing->isGroundBorder() || thing->isGround() || thing->isCreature())
                 break;
             thing->draw(dest - m_drawElevation*scaleFactor, scaleFactor, animate, lightView);
-
-            if(thing->isLyingCorpse()) {
-                redrawPreviousTopW = std::max<int>(thing->getWidth(), redrawPreviousTopW);
-                redrawPreviousTopH = std::max<int>(thing->getHeight(), redrawPreviousTopH);
-            }
-
             m_drawElevation += thing->getElevation();
             if(m_drawElevation > Otc::MAX_ELEVATION)
                 m_drawElevation = Otc::MAX_ELEVATION;
-        }
-    }
-
-    // after we render 2x2 lying corpses, we must redraw previous creatures/ontop above them
-    if(redrawPreviousTopH > 0 || redrawPreviousTopW > 0) {
-        int topRedrawFlags = drawFlags & (Otc::DrawCreatures | Otc::DrawEffects | Otc::DrawOnTop | Otc::DrawAnimations);
-        if(topRedrawFlags) {
-            for(int x=-redrawPreviousTopW;x<=0;++x) {
-                for(int y=-redrawPreviousTopH;y<=0;++y) {
-                    if(x == 0 && y == 0)
-                        continue;
-                    const TilePtr& tile = g_map.getTile(m_position.translated(x,y));
-                    if(tile)
-                        tile->draw(dest + Point(x*Otc::TILE_PIXELS, y*Otc::TILE_PIXELS)*scaleFactor, scaleFactor, topRedrawFlags);
-                }
-            }
         }
     }
 


### PR DESCRIPTION
In https://github.com/edubart/otclient/issues/1040#issuecomment-581173589 we had a discussion if tile:draw() redrawing in case of lying corpse either is needed or not. We came to conclusion that there are way too many downsides of this resolution and therefore we opt against redrawing. Both performance-wise and gameplay-wise it is better without redrawing.