### PR TITLE
Fix comma_value result treated as an int

### DIFF
--- a/modules/game_skills/skills.lua
+++ b/modules/game_skills/skills.lua
@@ -300,7 +300,7 @@ function onLevelChange(localPlayer, value, percent)
         local hoursLeft = (nextLevelExp - localPlayer:getExperience()) / expPerHour
         local minutesLeft = math.floor((hoursLeft - math.floor(hoursLeft))*60)
         hoursLeft = math.floor(hoursLeft)
-        text = text .. '\n' .. tr('%d of experience per hour', comma_value(expPerHour))
+        text = text .. '\n' .. tr('%s of experience per hour', comma_value(expPerHour))
         text = text .. '\n' .. tr('Next level in %d hours and %d minutes', hoursLeft, minutesLeft)
      end
   end


### PR DESCRIPTION
After applying 714c6b8fc01f9197288695621014ba193f809b7f (#1085), this should be changed too.

Terminal was spamming this warning even though it worked fine.