### PR TITLE
Slight fix of Tile::isLookPossible() function

### DIFF
--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -527,7 +527,7 @@ bool Tile::isSingleDimension()
 bool Tile::isLookPossible()
 {
     for(const ThingPtr& thing : m_things)
-        if(thing->blockProjectile())
+        if(thing->blockProjectile() && !thing->isTranslucent())
             return false;
     return true;
 }


### PR DESCRIPTION
You should see through things that are translucent.