### PR TITLE
resourcemanager:[bug fix] directoryExists method should resolvePath before checking

### DIFF
--- a/src/framework/core/resourcemanager.cpp
+++ b/src/framework/core/resourcemanager.cpp
@@ -156,14 +156,13 @@ void ResourceManager::searchAndAddPackages(const std::string& packagesDir, const
 
 bool ResourceManager::fileExists(const std::string& fileName)
 {
-    const std::string path = resolvePath(fileName);
-    return (PHYSFS_exists(path.c_str()) && !directoryExists(path));
+    return (PHYSFS_exists(resolvePath(fileName).c_str()) && !directoryExists(fileName));
 }
 
 bool ResourceManager::directoryExists(const std::string& directoryName)
 {
     PHYSFS_Stat stat = {};
-    if (!PHYSFS_stat(directoryName.c_str(), &stat)) {
+    if (!PHYSFS_stat(resolvePath(directoryName).c_str(), &stat)) {
         return false;
     }
 


### PR DESCRIPTION
https://github.com/otland/otclient/pull/43

Before directoryExists method called resolvePath on input. Later change was introduced that changed that behavior silently breaking some things(most notably CandyBot ui). This PR fixes that.