### PR TITLE
[creature] fix for laggy diagonal animation

### DIFF
--- a/src/client/creature.cpp
+++ b/src/client/creature.cpp
@@ -579,14 +579,14 @@ void Creature::nextWalkUpdate()
         m_walkUpdateEvent = g_dispatcher.scheduleEvent([self] {
             self->m_walkUpdateEvent = nullptr;
             self->nextWalkUpdate();
-        }, getStepDuration() / 32);
+        }, getStepDuration(true) / 32);
     }
 }
 
 void Creature::updateWalk()
 {
     float walkTicksPerPixel = getStepDuration(true) / 32;
-    int totalPixelsWalked = std::min<int>(m_walkTimer.ticksElapsed() / walkTicksPerPixel, 32.0f);
+    int totalPixelsWalked = std::min<int>(m_walkTimer.ticksElapsed() / walkTicksPerPixel, 32);
 
     // needed for paralyze effect
     m_walkedPixels = std::max<int>(m_walkedPixels, totalPixelsWalked);


### PR DESCRIPTION
https://github.com/otland/otclient/pull/50

proper fix for this long standing bug.

there are two interesting lines 609 and 615
609 controls how often creature should update it's internal offset from default tile position
615 controls (based on the speed and tile type) how much creature moved from previous time this function was called.

creators of previous solutions seemed to not care that this bug is only happening when moving diagonally and they was just changing global update rate

there are 4 different combination for this two method:
first column is for 609 line getStepDuration and second for 615

false / false
slower refresh when diagonal / slower movement speed when diagonal

false / true
slower refresh when diagonal / normal movement speed when diagonal

true / false:
normal refresh when diagonal / slower movement speed when diagonal

true / true:
normal refresh when diagonal / normal movement speed when diagonal

basically the false true is the worst option because it leaves movement speed as is and slower the position update rate

I don't remember how official tibia client looks like but the two sane options are
false / false
true / true

where true / true leaves speed as is(but there is longer period of time at the end when no movement is posible and the creature is not moving)

and false / false which adapt the movement speed when diagonal to be a little slower compared to nomal but the waiting period at the end of movement is shorter

there is no point in increasing refreshing period to much because event dispatcher granularity is only 1 ms. which is weird because is only the problem of event and scheduler interface and not the underlying clock interface which gives more granularity

and frame time for 60 fps is 16.(6) ms so more granularity than 1 ms would be good it seams to me

This only fixes creature animation for now. I decided to write this that way because there is also step duration that need to be changed.
After we decide what behavior we want then I will write a patch that also fixes player animation and have correct step duration.

Possible speeds:
lets define normal speed (horizontal and vertical) as 1tile per 1interval

so the normal animation speed is 1/1 = 1
when we move diagonally we have to spend 2 intervals of time on that.
but the distance is given by the Pythagorean theorem
1^2 + 1^2 = diagonal^2

so diagional = sqrt(2) or aprox 1.41

so we move 1.41/2 which is 0.7 or in other words 70% of the normal speed.
So we have two options
either we move at normal speed and then at the and wait a little bit not moving. Or we slow down while moving diagonally so we don't have to wait at the end of diagonal movement.


_Also it occurred to me that diagonally we have to move minimal by one pixel horizontally and on vertically. So  it can appear that we "jump" more than when moving just in one direction. We should take that into account when deciding what to do._