### PR TITLE
groundwork for more precise eventdispatcher

### DIFF
--- a/src/framework/core/eventdispatcher.cpp
+++ b/src/framework/core/eventdispatcher.cpp
@@ -74,13 +74,15 @@ void EventDispatcher::poll()
             event->execute();
         }
         m_pollEventsSize = m_eventList.size();
-        
+
         loops++;
     }
 }
 
 ScheduledEventPtr EventDispatcher::scheduleEvent(const std::function<void()>& callback, int delay)
 {
+    delay *= 1000;// SheduledEvent is in microseconds
+
     if(m_disabled)
         return ScheduledEventPtr(new ScheduledEvent(nullptr, delay, 1));
 
@@ -92,6 +94,8 @@ ScheduledEventPtr EventDispatcher::scheduleEvent(const std::function<void()>& ca
 
 ScheduledEventPtr EventDispatcher::cycleEvent(const std::function<void()>& callback, int delay)
 {
+    delay *= 1000;// SheduledEvent is in microseconds
+
     if(m_disabled)
         return ScheduledEventPtr(new ScheduledEvent(nullptr, delay, 0));
 
@@ -116,4 +120,3 @@ EventPtr EventDispatcher::addEvent(const std::function<void()>& callback, bool p
         m_eventList.push_back(event);
     return event;
 }
-

--- a/src/framework/core/eventdispatcher.h
+++ b/src/framework/core/eventdispatcher.h
@@ -40,7 +40,7 @@ public:
     ScheduledEventPtr cycleEvent(const std::function<void()>& callback, int delay);
 
 private:
-    std::list<EventPtr> m_eventList;
+    std::deque<EventPtr> m_eventList;
     int m_pollEventsSize;
     stdext::boolean<false> m_disabled;
     std::priority_queue<ScheduledEventPtr, std::vector<ScheduledEventPtr>, lessScheduledEvent> m_scheduledEventList;

--- a/src/framework/core/eventdispatcher.h
+++ b/src/framework/core/eventdispatcher.h
@@ -43,7 +43,7 @@ private:
     std::deque<EventPtr> m_eventList;
     int m_pollEventsSize;
     stdext::boolean<false> m_disabled;
-    std::priority_queue<ScheduledEventPtr, std::vector<ScheduledEventPtr>, lessScheduledEvent> m_scheduledEventList;
+    std::priority_queue<ScheduledEventPtr, std::deque<ScheduledEventPtr>, lessScheduledEvent> m_scheduledEventList;
 };
 
 extern EventDispatcher g_dispatcher;

--- a/src/framework/core/scheduledevent.cpp
+++ b/src/framework/core/scheduledevent.cpp
@@ -24,7 +24,7 @@
 
 ScheduledEvent::ScheduledEvent(const std::function<void()>& callback, int delay, int maxCycles) : Event(callback)
 {
-    m_ticks = g_clock.millis() + delay;
+    m_ticks = g_clock.micros() + delay;
     m_delay = delay;
     m_maxCycles = maxCycles;
     m_cyclesExecuted = 0;

--- a/src/framework/core/scheduledevent.h
+++ b/src/framework/core/scheduledevent.h
@@ -35,7 +35,7 @@ public:
     bool nextCycle();
 
     int ticks() { return m_ticks; }
-    int remainingTicks() { return m_ticks - g_clock.millis(); }
+    int remainingTicks() { return m_ticks - g_clock.micros(); }
     int delay() { return m_delay; }
     int cyclesExecuted() { return m_cyclesExecuted; }
     int maxCycles() { return m_maxCycles; }

--- a/src/framework/stdext/time.h
+++ b/src/framework/stdext/time.h
@@ -36,8 +36,8 @@ void microsleep(size_t us);
 struct timer {
 public:
     timer() { restart(); }
-    float elapsed_seconds() { return (float)((stdext::micros() - m_start)/1000000.0); }
-    ticks_t elapsed_millis() { return (stdext::micros() - m_start)/1000; }
+    float elapsed_seconds() { return (stdext::micros() - m_start) / 1000000.f; }
+    ticks_t elapsed_millis() { return (stdext::micros() - m_start) / 1000; }
     ticks_t elapsed_micros() { return stdext::micros() - m_start; }
     void restart() { m_start = stdext::micros(); }
 private:
@@ -47,4 +47,3 @@ private:
 }
 
 #endif
-


### PR DESCRIPTION
This pr changes sheduledevent to use microsecond instead of millisecond. This in the future will allow more precise event timing.

first patch. small cleanup
second patch. changes scheduledevent to use microseconds and update eventdispatcher for new interface(it's the only direct user of scheduledevent)
third patch. change std::list to std::deque. This is better data structure for the job it's performing(fifo queue with push_front and push_back).

Later I/we can add new interface to eventdispatcher so we can schedule events with more time granularity. 

Please review. Also please take a look at this pr https://github.com/edubart/otclient/pull/1102