### PR TITLE
Updated call to getLength

### DIFF
--- a/src/framework/util/point.h
+++ b/src/framework/util/point.h
@@ -77,7 +77,7 @@ public:
     T manhattanLength() const { return std::abs(x) + std::abs(y); }
 
     float distanceFrom(const TPoint<T>& other) const {
-        return TPoint<T>(x - other.x, y - other.y).getLength();
+        return TPoint<T>(x - other.x, y - other.y).length();
     }
 
     T x, y;


### PR DESCRIPTION
There is no method named after getLength inside TPoint, and once this is a template implementation the error will only show up when trying to use distanceFrom method.