### PR TITLE
[tile] return vector by const ref instead of copy

### DIFF
--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -88,8 +88,8 @@ public:
     int getDrawElevation() { return m_drawElevation; }
     std::vector<ItemPtr> getItems();
     std::vector<CreaturePtr> getCreatures();
-    std::vector<CreaturePtr> getWalkingCreatures() { return m_walkingCreatures; }
-    std::vector<ThingPtr> getThings() { return m_things; }
+    const std::vector<CreaturePtr>& getWalkingCreatures() { return m_walkingCreatures; }
+    const std::vector<ThingPtr>& getThings() { return m_things; }
     ItemPtr getGround();
     int getGroundSpeed();
     uint8 getMinimapColorByte();


### PR DESCRIPTION
This patch returns vector by const ref instead of making copy. If the copy is needed the calling function can make it instead. In remaining two cases we are creating new vectors so we can't do that. New vectors should be returned by RVO so it shouldn't be a problem.