### PR TITLE
Fix for Oldschool Tibia Light System (7.x)

### DIFF
--- a/src/client/lightview.cpp
+++ b/src/client/lightview.cpp
@@ -28,6 +28,9 @@
 #include <framework/graphics/image.h>
 
 enum {
+#ifdef OLDSCHOOL_LIGHT
+    MAX_LIGHT_INTENSITY = 15,
+#endif
     MAX_LIGHT_INTENSITY = 8,
     MAX_AMBIENT_LIGHT_INTENSITY = 255
 };


### PR DESCRIPTION
The oldschool Tibia formulas for Light Spells go as following: (Light: 6 light intensity, Great Light: 8 light intensitiy, Ultimate Light: 10 light intensity). Clearly by using 8 we're capping the distance where ambientLight is drawn.

Since this all is mostly sent by lua spells from TFS to the client, having optional full light (with a gamemaster for example) is just nice, as 10 only won't make the whole view range bright.

You can also limit this via modules if you don't want your players having 