### PR TITLE
Run windows workflow with luajit only

### DIFF
--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -56,6 +56,9 @@ jobs:
             packages: >
               boost-iostreams boost-asio boost-system boost-variant boost-lockfree glew
               boost-filesystem boost-uuid openal-soft libogg libvorbis zlib opengl
+        exclude:
+          - name: windows-msvc
+            luajit: off
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
vcpkg does not provide [version of lua](https://github.com/microsoft/vcpkg/blob/master/versions/l-/lua.json) that could be used to compile otclient.