### PR TITLE
keep logs in deque and don't make unnecessary copy

### DIFF
--- a/src/framework/core/logger.h
+++ b/src/framework/core/logger.h
@@ -59,7 +59,7 @@ public:
     void setOnLog(const OnLogCallback& onLog) { m_onLog = onLog; }
 
 private:
-    std::list<LogMessage> m_logMessages;
+    std::deque<LogMessage> m_logMessages;
     OnLogCallback m_onLog;
     std::ofstream m_outFile;
     std::recursive_mutex m_mutex;


### PR DESCRIPTION
Some small improvements after that caught my attention. We don't need to make a copy because 'm_onLog' can't change anything. I think onLog is used when you bring up client console so lua can show you logs.