### PR TITLE
use float literals

### DIFF
--- a/src/client/position.h
+++ b/src/client/position.h
@@ -154,21 +154,21 @@ public:
     {
         float angle = getAngleFromPositions(fromPos, toPos) * RAD_TO_DEC;
 
-        if(angle >= 360 - 22.5 || angle < 0 + 22.5)
+        if(angle >= 360 - 22.5f || angle < 0 + 22.5f)
             return Otc::East;
-        else if(angle >= 45 - 22.5 && angle < 45 + 22.5)
+        else if(angle >= 45 - 22.5f && angle < 45 + 22.5f)
             return Otc::NorthEast;
-        else if(angle >= 90 - 22.5 && angle < 90 + 22.5)
+        else if(angle >= 90 - 22.5f && angle < 90 + 22.5f)
             return Otc::North;
-        else if(angle >= 135 - 22.5 && angle < 135 + 22.5)
+        else if(angle >= 135 - 22.5f && angle < 135 + 22.5f)
             return Otc::NorthWest;
-        else if(angle >= 180 - 22.5 && angle < 180 + 22.5)
+        else if(angle >= 180 - 22.5f && angle < 180 + 22.5f)
             return Otc::West;
-        else if(angle >= 225 - 22.5 && angle < 225 + 22.5)
+        else if(angle >= 225 - 22.5f && angle < 225 + 22.5f)
             return Otc::SouthWest;
-        else if(angle >= 270 - 22.5 && angle < 270 + 22.5)
+        else if(angle >= 270 - 22.5f && angle < 270 + 22.5f)
             return Otc::South;
-        else if(angle >= 315 - 22.5 && angle < 315 + 22.5)
+        else if(angle >= 315 - 22.5f && angle < 315 + 22.5f)
             return Otc::SouthEast;
         else
             return Otc::InvalidDirection;

--- a/src/framework/const.h
+++ b/src/framework/const.h
@@ -25,8 +25,8 @@
 
 #include "stdext/compiler.h"
 
-#define DEG_TO_RAD (acos(-1)/180.0)
-#define RAD_TO_DEC (180.0/acos(-1))
+#define DEG_TO_RAD (std::acos(-1.f)/180.f)
+#define RAD_TO_DEC (180.f/std::acos(-1.f))
 
 #ifndef BUILD_COMMIT
 #define BUILD_COMMIT "devel"
@@ -52,7 +52,7 @@
 
 namespace Fw
 {
-    static const float pi = 3.14159265;
+    static const float pi = 3.14159265f;
     static const float MIN_ALPHA = 0.003f;
     enum Key : unsigned char {
         KeyUnknown = 0,

--- a/src/framework/graphics/particleaffector.cpp
+++ b/src/framework/graphics/particleaffector.cpp
@@ -77,7 +77,7 @@ void GravityAffector::load(const OTMLNodePtr& node)
     ParticleAffector::load(node);
 
     m_angle = 270 * DEG_TO_RAD;
-    m_gravity = 9.8;
+    m_gravity = 9.8f;
 
     for(const OTMLNodePtr& childNode : node->children()) {
         if(childNode->tag() == "angle")
@@ -132,5 +132,5 @@ void AttractionAffector::updateParticle(const ParticlePtr& particle, float elaps
         direction = PointF(-1, -1);
 
     PointF pVelocity = particle->getVelocity() + (d / d.length() * m_acceleration * elapsedTime) * direction;
-    particle->setVelocity(pVelocity - pVelocity * m_reduction/100.0 * elapsedTime);
+    particle->setVelocity(pVelocity - pVelocity * m_reduction/100.f * elapsedTime);
 }


### PR DESCRIPTION
Use float literals to perform more calculation in float instead of performing implicit conversion to double and back to float.