### PR TITLE
bitmapfont: allow for more than 256 glyphs

### DIFF
--- a/src/framework/graphics/bitmapfont.cpp
+++ b/src/framework/graphics/bitmapfont.cpp
@@ -49,9 +49,14 @@ void BitmapFont::load(const OTMLNodePtr& fontNode)
     // load font texture
     m_texture = g_textures.getTexture(textureFile);
     Size textureSize = m_texture->getSize();
+    int numHorizontalGlyphs = textureSize.width() / glyphSize.width();
+    int numVerticalGlyphs = textureSize.height() / glyphSize.height();
+    int numGlyphs = numHorizontalGlyphs * numVerticalGlyphs;
+    m_glyphsTextureCoords.resize(numGlyphs);
+    m_glyphsSize.resize(numGlyphs);
 
     if(OTMLNodePtr node = fontNode->get("fixed-glyph-width")) {
-        for(int glyph = m_firstGlyph; glyph < 256; ++glyph)
+        for(int glyph = m_firstGlyph; glyph < numGlyphs; ++glyph)
             m_glyphsSize[glyph] = Size(node->value<int>(), m_glyphHeight);
     } else {
         calculateGlyphsWidthsAutomatically(Image::load(textureFile), glyphSize);
@@ -77,8 +82,7 @@ void BitmapFont::load(const OTMLNodePtr& fontNode)
 
 
     // calculate glyphs texture coords
-    int numHorizontalGlyphs = textureSize.width() / glyphSize.width();
-    for(int glyph = m_firstGlyph; glyph < 256; ++glyph) {
+    for(int glyph = m_firstGlyph; glyph < numGlyphs; ++glyph) {
         m_glyphsTextureCoords[glyph].setRect(((glyph - m_firstGlyph) % numHorizontalGlyphs) * glyphSize.width(),
                                                 ((glyph - m_firstGlyph) / numHorizontalGlyphs) * glyphSize.height(),
                                                 m_glyphsSize[glyph].width(),
@@ -271,10 +275,12 @@ void BitmapFont::calculateGlyphsWidthsAutomatically(const ImagePtr& image, const
 
     Size imageSize = image->getSize();
     int numHorizontalGlyphs = imageSize.width() / glyphSize.width();
+    int numVerticalGlyphs = imageSize.height() / glyphSize.height();
+    int numGlyphs = numHorizontalGlyphs * numVerticalGlyphs;
     const auto& texturePixels = image->getPixels();
 
     // small AI to auto calculate pixels widths
-    for(int glyph = m_firstGlyph; glyph < 256; ++glyph) {
+    for(int glyph = m_firstGlyph; glyph < numGlyphs; ++glyph) {
         Rect glyphCoords(((glyph - m_firstGlyph) % numHorizontalGlyphs) * glyphSize.width(),
                          ((glyph - m_firstGlyph) / numHorizontalGlyphs) * glyphSize.height(),
                             glyphSize.width(),

--- a/src/framework/graphics/bitmapfont.h
+++ b/src/framework/graphics/bitmapfont.h
@@ -57,8 +57,8 @@ public:
 
     const std::string& getName() { return m_name; }
     int getGlyphHeight() { return m_glyphHeight; }
-    const Rect* getGlyphsTextureCoords() { return m_glyphsTextureCoords; }
-    const Size* getGlyphsSize() { return m_glyphsSize; }
+    const std::vector<Rect>& getGlyphsTextureCoords() { return m_glyphsTextureCoords; }
+    const std::vector<Size>& getGlyphsSize() { return m_glyphsSize; }
     const TexturePtr& getTexture() { return m_texture; }
     int getYOffset() { return m_yOffset; }
     Size getGlyphSpacing() { return m_glyphSpacing; }
@@ -73,8 +73,8 @@ private:
     int m_yOffset;
     Size m_glyphSpacing;
     TexturePtr m_texture;
-    Rect m_glyphsTextureCoords[256];
-    Size m_glyphsSize[256];
+    std::vector<Rect> m_glyphsTextureCoords;
+    std::vector<Size> m_glyphsSize;
 };
 
 

--- a/src/framework/ui/uitextedit.cpp
+++ b/src/framework/ui/uitextedit.cpp
@@ -143,8 +143,8 @@ void UITextEdit::update(bool focusCursor)
     // map glyphs positions
     Size textBoxSize;
     const auto& glyphsPositions = m_font->calculateGlyphsPositions(text, m_textAlign, &textBoxSize);
-    const Rect* glyphsTextureCoords = m_font->getGlyphsTextureCoords();
-    const Size* glyphsSize = m_font->getGlyphsSize();
+    const auto& glyphsTextureCoords = m_font->getGlyphsTextureCoords();
+    const auto& glyphsSize = m_font->getGlyphsSize();
     int glyph;
 
     // update rect size


### PR DESCRIPTION
Second step in unicode support. This PR adds support for more glyhps in font.

We have two ways from now. Either we use utf8 encoding and then make function that manipulate strings utf8 aware, or we use something like std::wstring so one "char" can hold more codepoints. The upside is that we basically just use bigger font and std::wstring in places that we want unicode and that it. Also I thing that with current font system, 16bit codepoints is maximum that we can reasonably use. So no Chinese characters. Any thoughts? And what to focus on? Do we want to use unicode in interfaces or chat first? What encoding to use in network messages?