### PR TITLE
Optimize XTEA encryption

### DIFF
--- a/src/framework/net/protocol.h
+++ b/src/framework/net/protocol.h
@@ -48,8 +48,8 @@ public:
     void setConnection(const ConnectionPtr& connection) { m_connection = connection; }
 
     void generateXteaKey();
-    void setXteaKey(uint32 a, uint32 b, uint32 c, uint32 d);
-    std::vector<uint32> getXteaKey();
+    void setXteaKey(uint32 a, uint32 b, uint32 c, uint32 d) { m_xteaKey = {a, b, c, d}; }
+    std::vector<uint32> getXteaKey() { return {m_xteaKey.begin(), m_xteaKey.end()}; }
     void enableXteaEncryption() { m_xteaEncryptionEnabled = true; }
 
     void enableChecksum() { m_checksumEnabled = true; }
@@ -64,7 +64,7 @@ protected:
     virtual void onRecv(const InputMessagePtr& inputMessage);
     virtual void onError(const boost::system::error_code& err);
 
-    uint32 m_xteaKey[4];
+    std::array<uint32, 4> m_xteaKey;
 
 private:
     void internalRecvHeader(uint8* buffer, uint16 size);


### PR DESCRIPTION
Pushing the same code present in TFS. Tired of seeing this being sold in plain sight :stuck_out_tongue_closed_eyes: 

"This patch enables auto-vectorization for XTEA encryption and decryption, exploring vector (SSE, AVX) instructions to be auto-enabled by the compiler. Should render up to 16x faster encryption/decryption throughput on AVX2, 8x on AVX and 4x on SSE/Neon."

"Out with all that optimal block size width, let the compiler figure it out. Reduces the amount of code by half and increases performance by ~20%."

[Reasoning and detailed study](https://dev.to/rsa/making-an-algorithm-15x-faster-without-parallelism-38k5)