### PR TITLE
Option for loading data/modules/init.lua from encrypted zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,84 +1,20 @@
-[![Build Status](https://github.com/edubart/otclient/actions/workflows/build-vcpkg.yml/badge.svg)](https://github.com/edubart/otclient/actions/workflows/build-vcpkg.yml) [![Join the chat at https://gitter.im/edubart/otclient](https://img.shields.io/badge/GITTER-join%20chat-green.svg)](https://gitter.im/edubart/otclient?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Open Source Helpers](https://www.codetriage.com/edubart/otclient/badges/users.svg)](https://www.codetriage.com/edubart/otclient)
+Working on reforming and improving the Open Tibia community using democratic voting, open source software and software models (replicable data), and general optimism and support of the different Open Tibia communities and members.
+Join us at https://opentibia.dev/ and click the discord icon.
 
-### What is otclient?
+### Otclient with support for loading of encrypted zipped data/modules
 
-Otclient is an alternative Tibia client for usage with otserv. It aims to be complete and flexible,
-for that it uses LUA scripting for all game interface functionality and configurations files with a syntax
-similar to CSS for the client interface design. Otclient works with a modular system, this means
-that each functionality is a separated module, giving the possibility to users modify and customize
-anything easily. Users can also create new mods and extend game interface for their own purposes.
-Otclient is written in C++11 and heavily scripted in lua.
+Otclient can now load data/modules/init.lua from data.zip and modules.zip by setting the preprocessor ZIPENCRYPTION.
+The zips must be encrypted with ZipCrypto, not AES.
+Default password m_zipPassword = "12345678" is set in src/framework/core/resourcemanager.h.
+Init.lua must be included in either data.zip or modules.zip.
 
-For a server to connect to, you can build your own with the [forgottenserver](https://github.com/otland/forgottenserver)
-or connect to one listed on [otservlist](https://otservlist.org/).
+To create encrypted zips:
 
-### Where do I download?
+*    Install 7-zip
+*    Copy init.lua into data
+*    Go into data
+*    Select all, right click, 7-zip, Add to archive...
+*    Set password and ZipCrypto as encryption method
+*    Repeat for modules directory
 
-Compiled for Windows can be found here (but can be outdated):
-* [Windows Builds](http://otland.net/threads/otclient-builds-windows.217977/)
-
-**NOTE:** You will need to download spr/dat files on your own and place them in `data/things/VERSION/` (i.e: `data/things/1098/Tibia.spr`)
-
-### Features
-
-Beyond of it's flexibility with scripts, otclient comes with tons of other features that make possible
-the creation of new client side stuff in otserv that was not possible before. These include,
-sound system, graphics effects with shaders, modules/addons system, animated textures,
-styleable user interface, transparency, multi language, in game lua terminal, an OpenGL 1.1/2.0 ES engine that make possible
-to port to mobile platforms. Otclient is also flexible enough to
-create tibia tools like map editors just using scripts, because it wasn't designed to be just a
-client, instead otclient was designed to be a combination of a framework and tibia APIs.
-
-### Compiling
-
-In short, if you need to compile OTClient, follow these tutorials:
-* [Compiling on Windows](https://github.com/edubart/otclient/wiki/Compiling-on-Windows)
-* [Compiling on Linux](https://github.com/edubart/otclient/wiki/Compiling-on-Linux)
-* [Compiling on OS X](https://github.com/edubart/otclient/wiki/Compiling-on-Mac-OS-X)
-
-### Build and run with Docker
-
-To build the image:
-
-```sh
-docker build -t edubart/otclient .
-```
-
-To run the built image:
-
-```sh
-# Disable access control for the X server.
-xhost +
-
-# Run the container image with the required bindings to the host devices and volumes.
-docker run -it --rm \
-  --env DISPLAY \
-  --volume /tmp/.X11-unix:/tmp/.X11-unix \
-  --device /dev/dri \
-  --device /dev/snd edubart/otclient /bin/bash
-
-# Enable access control for the X server.
-xhost -
-```
-
-### Need help?
-
-Try to ask questions in [otland](http://otland.net/f494/), now we have a board for the project there,
-or talk with us at the gitter chat.
-
-### Bugs
-
-Have found a bug? Please create an issue in our [bug tracker](https://github.com/edubart/otclient/issues)
-
-### Contributing
-
-We encourage you to contribute to otclient! You can make pull requests of any improvement in our github page, alternatively, see [Contributing Wiki Page](https://github.com/edubart/otclient/wiki/Contributing).
-
-### Contact
-
-Talk directly with us at the gitter chat [![Join the chat at https://gitter.im/edubart/otclient](https://img.shields.io/badge/GITTER-join%20chat-green.svg)](https://gitter.im/edubart/otclient?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge).
-
-### License
-
-Otclient is made available under the MIT License, thus this means that you are free
-to do whatever you want, commercial, non-commercial, closed or open.
+Credits to Zelek for most of this (I tweaked/fixed it a little). Paid him $18 for this in mid-late 2020.

--- a/init.lua
+++ b/init.lua
@@ -8,14 +8,16 @@ g_logger.info(os.date("== application started at %b %d %Y %X"))
 -- print first terminal message
 g_logger.info(g_app.getName() .. ' ' .. g_app.getVersion() .. ' rev ' .. g_app.getBuildRevision() .. ' (' .. g_app.getBuildCommit() .. ') built on ' .. g_app.getBuildDate() .. ' for arch ' .. g_app.getBuildArch())
 
--- add data directory to the search path
-if not g_resources.addSearchPath(g_resources.getWorkDir() .. "data", true) then
-  g_logger.fatal("Unable to add data directory to the search path.")
-end
+if not g_app.isZipEncrypted() then
+  -- add data directory to the search path
+  if not g_resources.addSearchPath(g_resources.getWorkDir() .. "data", true) then
+    g_logger.fatal("Unable to add data directory to the search path.")
+  end
 
--- add modules directory to the search path
-if not g_resources.addSearchPath(g_resources.getWorkDir() .. "modules", true) then
-  g_logger.fatal("Unable to add modules directory to the search path.")
+  -- add modules directory to the search path
+  if not g_resources.addSearchPath(g_resources.getWorkDir() .. "modules", true) then
+    g_logger.fatal("Unable to add modules directory to the search path.")
+  end
 end
 
 -- try to add mods path too
@@ -50,6 +52,8 @@ g_modules.autoLoadModules(9999)
 
 local script = '/' .. g_app.getCompactName() .. 'rc.lua'
 
-if g_resources.fileExists(script) then
-  dofile(script)
+if not g_app.isZipEncrypted() then
+  if g_resources.fileExists(script) then
+    dofile(script)
+  end
 end

--- a/src/framework/core/graphicalapplication.h
+++ b/src/framework/core/graphicalapplication.h
@@ -52,6 +52,12 @@ public:
     int getBackgroundPaneFps() { return m_backgroundFrameCounter.getLastFps(); }
     int getForegroundPaneMaxFps() { return m_foregroundFrameCounter.getMaxFps(); }
     int getBackgroundPaneMaxFps() { return m_backgroundFrameCounter.getMaxFps(); }
+    bool isZipEncrypted() {
+#ifdef ZIPENCRYPTION
+        return true;
+#endif
+        return false;
+    }
 
     bool isOnInputEvent() { return m_onInputEvent; }
 

--- a/src/framework/core/resourcemanager.cpp
+++ b/src/framework/core/resourcemanager.cpp
@@ -185,7 +185,15 @@ std::string ResourceManager::readFileContents(const std::string& fileName)
 {
     std::string fullPath = resolvePath(fileName);
 
-    PHYSFS_File* file = PHYSFS_openRead(fullPath.c_str());
+    PHYSFS_File* file;
+#ifdef ZIPENCRYPTION
+    if(fileName != "/config.otml")
+        file = PHYSFS_openRead(std::string(fullPath + "$" + m_zipPassword).c_str());
+    else
+        file = PHYSFS_openRead(fullPath.c_str());
+#else
+        file = PHYSFS_openRead(fullPath.c_str());
+#endif
     if(!file)
         stdext::throw_exception(stdext::format("unable to open file '%s': %s", fullPath, PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode())));
 
@@ -232,7 +240,12 @@ FileStreamPtr ResourceManager::openFile(const std::string& fileName)
 {
     std::string fullPath = resolvePath(fileName);
 
-    PHYSFS_File* file = PHYSFS_openRead(fullPath.c_str());
+    PHYSFS_File* file;
+#ifdef ZIPENCRYPTION
+    file = PHYSFS_openRead(std::string(fullPath + "$" + m_zipPassword).c_str());
+#else
+    file = PHYSFS_openRead(fullPath.c_str());
+#endif
     if(!file)
         stdext::throw_exception(stdext::format("unable to open file '%s': %s", fullPath, PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode())));
     return FileStreamPtr(new FileStream(fullPath, file, false));

--- a/src/framework/core/resourcemanager.h
+++ b/src/framework/core/resourcemanager.h
@@ -75,6 +75,7 @@ public:
     std::string getWriteDir() { return m_writeDir; }
     std::string getWorkDir() { return m_workDir; }
     std::deque<std::string> getSearchPaths() { return m_searchPaths; }
+    std::string m_zipPassword = "12345678";
 
     std::string guessFilePath(const std::string& filename, const std::string& type);
     bool isFileType(const std::string& filename, const std::string& type);

--- a/src/framework/luafunctions.cpp
+++ b/src/framework/luafunctions.cpp
@@ -252,6 +252,7 @@ void Application::registerLuaFunctions()
     g_lua.bindSingletonFunction("g_app", "getBackgroundPaneFps", &GraphicalApplication::getBackgroundPaneFps, &g_app);
     g_lua.bindSingletonFunction("g_app", "getForegroundPaneMaxFps", &GraphicalApplication::getForegroundPaneMaxFps, &g_app);
     g_lua.bindSingletonFunction("g_app", "getBackgroundPaneMaxFps", &GraphicalApplication::getBackgroundPaneMaxFps, &g_app);
+    g_lua.bindSingletonFunction("g_app", "isZipEncrypted", &GraphicalApplication::isZipEncrypted, &g_app);
 
     // PlatformWindow
     g_lua.registerSingletonClass("g_window");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,12 +39,27 @@ int main(int argc, const char* argv[])
     g_client.init(args);
 
     // find script init.lua and run it
-    if(!g_resources.discoverWorkDir("init.lua"))
+    if(!g_resources.discoverWorkDir(g_app.getCompactName() + ".exe"))
         g_logger.fatal("Unable to find work directory, the application cannot be initialized.");
 
-    if(!g_lua.safeRunScript("init.lua"))
-        g_logger.fatal("Unable to run script init.lua!");
+#ifdef ZIPENCRYPTION
+    if (!g_resources.addSearchPath(g_resources.getWorkDir() + "data.zip", true))
+        g_logger.fatal("Unable to add data to the search path");
+    if (!g_resources.addSearchPath(g_resources.getWorkDir() + "modules.zip", true))
+        g_logger.fatal("Unable to add modules to the search path");
 
+    if (!g_lua.safeRunScript("init.lua"))
+        g_logger.fatal("Unable to run script init.lua!");
+#else
+    if (!g_lua.safeRunScript("init.lua"))
+    {
+        if (!g_resources.addSearchPath(g_resources.getWorkDir() + "data", true))
+            g_logger.fatal("Unable to add data to the search path");
+
+        if (!g_lua.safeRunScript("init.lua"))
+            g_logger.fatal("Unable to run script init.lua!");
+    }
+#endif
     // the run application main loop
     g_app.run();
 


### PR DESCRIPTION
Otclient can now load data/modules/init.lua from data.zip and modules.zip by setting the preprocessor ZIPENCRYPTION.
The zips must be encrypted with ZipCrypto, not AES.
Default password m_zipPassword = "12345678" and is set in src/framework/core/resourcemanager.h.
Init.lua must be included in either data.zip or modules.zip.

To create encrypted zips:
1. Install 7-zip
2. Copy init.lua into data
3. Go into data
4. Select all, right click, 7-zip, Add to archive...
5. Set password and ZipCrypto as encryption method
6. Repeat for modules directory

Credits to Zelek. Paid him $18 for this 8 months ago.