### PR TITLE
Greeting npc on left click

### DIFF
--- a/modules/game_battle/battle.lua
+++ b/modules/game_battle/battle.lua
@@ -502,6 +502,10 @@ function onBattleButtonMouseRelease(self, mousePosition, mouseButton)
     if self.isTarget then
       g_game.cancelAttack()
     else
+      if self.creature:isNpc() then
+        modules.game_interface.checkMaxDistanceToGreetingNpc(g_game.getLocalPlayer(), self.creature)
+        return false
+      end
       g_game.attack(self.creature)
     end
     return true


### PR DESCRIPTION
- [x] Option to choose a max distance to talk him
`maxDistanceToGreetingNpc = 3`

- [x] Table with greetings words
`focusGreetWords = {"hi", "hello"}`

- [x] Random the words
`g_game.talk(focusGreetWords[math.random(1, #focusGreetWords)])`

- [x] Change a right click option on npc, attack option to talk option.

     [https://github.com/edubart/otclient/compare/master...alfuveam:greeting_npc_hi?expand=1#diff-1b975e904a1c9756dc22f83fbc9884012958e3c3f158bc081aaa6c49dfa2f585L557-R569](url)

