### PR TITLE
Fix minimap black tiles replacing color tiles

### DIFF
--- a/src/client/creature.cpp
+++ b/src/client/creature.cpp
@@ -557,7 +557,7 @@ void Creature::updateWalkingTile()
             newWalkingTile->addWalkingCreature(static_self_cast<Creature>());
 
             // recache visible tiles in map views
-            if(newWalkingTile->isEmpty())
+            if(!newWalkingTile->isEmpty())
                 g_map.notificateTileUpdate(newWalkingTile->getPosition());
         }
         m_walkingTile = newWalkingTile;

--- a/src/client/creature.cpp
+++ b/src/client/creature.cpp
@@ -556,9 +556,11 @@ void Creature::updateWalkingTile()
         if(newWalkingTile) {
             newWalkingTile->addWalkingCreature(static_self_cast<Creature>());
 
+            /*
             // recache visible tiles in map views
             if(!newWalkingTile->isEmpty())
                 g_map.notificateTileUpdate(newWalkingTile->getPosition());
+            */
         }
         m_walkingTile = newWalkingTile;
     }

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -550,7 +550,7 @@ bool Tile::isClickable()
 
 bool Tile::isEmpty()
 {
-    return m_things.size() == 0;
+    return m_things.empty();
 }
 
 bool Tile::isDrawable()


### PR DESCRIPTION
Monsters moving just outside visible map region where causing black tiles to replace color tiles on minimap. I thing that was caused by new empty tiles created to hold information about moving monsters. `!newWalkingTile->isEmpty` fixed this. This was added  because https://github.com/edubart/otclient/issues/103 . I was not able to reproduce it and I'm not sure how the original update on empty tiles was supposed to fix it. It was some time ago so perhaps other changes fixed the other issue and introduced this one.

@edit I was able to reproduce issue/103 :(

please review

Thanks.