### PR TITLE
move big functions from .h to .cpp

### DIFF
--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -550,7 +550,7 @@ bool Tile::isClickable()
 
 bool Tile::isEmpty()
 {
-    return m_things.size() == 0;
+    return m_things.empty();
 }
 
 bool Tile::isDrawable()

--- a/src/framework/util/color.cpp
+++ b/src/framework/util/color.cpp
@@ -21,30 +21,108 @@
  */
 
 #include "color.h"
+#include <iomanip>
 
 // NOTE: AABBGGRR order
 const Color Color::alpha      = 0x00000000U;
-const Color Color::white      = 0xffffffff;
-const Color Color::black      = 0xff000000;
-const Color Color::red        = 0xff0000ff;
-const Color Color::darkRed    = 0xff000080;
-const Color Color::green      = 0xff00ff00;
-const Color Color::darkGreen  = 0xff008000;
-const Color Color::blue       = 0xffff0000;
-const Color Color::darkBlue   = 0xff800000;
-const Color Color::pink       = 0xffff00ff;
-const Color Color::darkPink   = 0xff800080;
-const Color Color::yellow     = 0xff00ffff;
-const Color Color::darkYellow = 0xff008080;
-const Color Color::teal       = 0xffffff00;
-const Color Color::darkTeal   = 0xff808000;
-const Color Color::gray       = 0xffa0a0a0;
-const Color Color::darkGray   = 0xff808080;
-const Color Color::lightGray  = 0xffc0c0c0;
-const Color Color::orange     = 0xff008cff;
+const Color Color::white      = 0xffffffffU;
+const Color Color::black      = 0xff000000U;
+const Color Color::red        = 0xff0000ffU;
+const Color Color::darkRed    = 0xff000080U;
+const Color Color::green      = 0xff00ff00U;
+const Color Color::darkGreen  = 0xff008000U;
+const Color Color::blue       = 0xffff0000U;
+const Color Color::darkBlue   = 0xff800000U;
+const Color Color::pink       = 0xffff00ffU;
+const Color Color::darkPink   = 0xff800080U;
+const Color Color::yellow     = 0xff00ffffU;
+const Color Color::darkYellow = 0xff008080U;
+const Color Color::teal       = 0xffffff00U;
+const Color Color::darkTeal   = 0xff808000U;
+const Color Color::gray       = 0xffa0a0a0U;
+const Color Color::darkGray   = 0xff808080U;
+const Color Color::lightGray  = 0xffc0c0c0U;
+const Color Color::orange     = 0xff008cffU;
 
 Color::Color(const std::string& coltext)
 {
     std::stringstream ss(coltext);
     ss >> *this;
+}
+
+std::ostream& operator<<(std::ostream& out, const Color& color)
+{
+    return out << '#'
+           << std::hex << std::setfill('0')
+           << std::setw(2) << (int)color.r()
+           << std::setw(2) << (int)color.g()
+           << std::setw(2) << (int)color.b()
+           << std::setw(2) << (int)color.a()
+           << std::dec << std::setfill(' ');
+}
+
+std::istream& operator>>(std::istream& in, Color& color)
+{
+    std::string tmp;
+
+    if(in.peek() == '#') {
+        in.ignore() >> tmp;
+
+        if(tmp.length() == 6 || tmp.length() == 8) {
+            color.setRed((uint8)stdext::hex_to_dec(tmp.substr(0, 2)));
+            color.setGreen((uint8)stdext::hex_to_dec(tmp.substr(2, 2)));
+            color.setBlue((uint8)stdext::hex_to_dec(tmp.substr(4, 2)));
+            if(tmp.length() == 8)
+                color.setAlpha((uint8)stdext::hex_to_dec(tmp.substr(6, 2)));
+            else
+                color.setAlpha(255);
+        } else {
+            in.seekg(-tmp.length()-1, std::ios_base::cur);
+        }
+    } else {
+        in >> tmp;
+
+        if(tmp == "alpha") {
+            color = Color::alpha;
+        } else if(tmp == "black") {
+            color = Color::black;
+        } else if(tmp == "white") {
+            color = Color::white;
+        } else if(tmp == "red") {
+            color = Color::red;
+        } else if(tmp == "darkRed") {
+            color = Color::darkRed;
+        } else if(tmp == "green") {
+            color = Color::green;
+        } else if(tmp == "darkGreen") {
+            color = Color::darkGreen;
+        } else if(tmp == "blue") {
+            color = Color::blue;
+        } else if(tmp == "darkBlue") {
+            color = Color::darkBlue;
+        } else if(tmp == "pink") {
+            color = Color::pink;
+        } else if(tmp == "darkPink") {
+            color = Color::darkPink;
+        } else if(tmp == "yellow") {
+            color = Color::yellow;
+        } else if(tmp == "darkYellow") {
+            color = Color::darkYellow;
+        } else if(tmp == "teal") {
+            color = Color::teal;
+        } else if(tmp == "darkTeal") {
+            color = Color::darkTeal;
+        } else if(tmp == "gray") {
+            color = Color::gray;
+        } else if(tmp == "darkGray") {
+            color = Color::darkGray;
+        } else if(tmp == "lightGray") {
+            color = Color::lightGray;
+        } else if(tmp == "orange") {
+            color = Color::orange;
+        } else {
+            in.seekg(-tmp.length(), std::ios_base::cur);
+        }
+    }
+    return in;
 }

--- a/src/framework/util/color.h
+++ b/src/framework/util/color.h
@@ -27,7 +27,6 @@
 #include "../stdext/cast.h"
 #include "../stdext/string.h"
 #include "../const.h"
-#include <iomanip>
 
 class Color
 {
@@ -124,81 +123,7 @@ private:
     float m_a;
 };
 
-inline std::ostream& operator<<(std::ostream& out, const Color& color)
-{
-    return out << '#'
-           << std::hex << std::setfill('0')
-           << std::setw(2) << (int)color.r()
-           << std::setw(2) << (int)color.g()
-           << std::setw(2) << (int)color.b()
-           << std::setw(2) << (int)color.a()
-           << std::dec << std::setfill(' ');
-}
-
-inline std::istream& operator>>(std::istream& in, Color& color)
-{
-    std::string tmp;
-
-    if(in.peek() == '#') {
-        in.ignore() >> tmp;
-
-        if(tmp.length() == 6 || tmp.length() == 8) {
-            color.setRed((uint8)stdext::hex_to_dec(tmp.substr(0, 2)));
-            color.setGreen((uint8)stdext::hex_to_dec(tmp.substr(2, 2)));
-            color.setBlue((uint8)stdext::hex_to_dec(tmp.substr(4, 2)));
-            if(tmp.length() == 8)
-                color.setAlpha((uint8)stdext::hex_to_dec(tmp.substr(6, 2)));
-            else
-                color.setAlpha(255);
-        } else {
-            in.seekg(-tmp.length()-1, std::ios_base::cur);
-        }
-    } else {
-        in >> tmp;
-
-        if(tmp == "alpha") {
-            color = Color::alpha;
-        } else if(tmp == "black") {
-            color = Color::black;
-        } else if(tmp == "white") {
-            color = Color::white;
-        } else if(tmp == "red") {
-            color = Color::red;
-        } else if(tmp == "darkRed") {
-            color = Color::darkRed;
-        } else if(tmp == "green") {
-            color = Color::green;
-        } else if(tmp == "darkGreen") {
-            color = Color::darkGreen;
-        } else if(tmp == "blue") {
-            color = Color::blue;
-        } else if(tmp == "darkBlue") {
-            color = Color::darkBlue;
-        } else if(tmp == "pink") {
-            color = Color::pink;
-        } else if(tmp == "darkPink") {
-            color = Color::darkPink;
-        } else if(tmp == "yellow") {
-            color = Color::yellow;
-        } else if(tmp == "darkYellow") {
-            color = Color::darkYellow;
-        } else if(tmp == "teal") {
-            color = Color::teal;
-        } else if(tmp == "darkTeal") {
-            color = Color::darkTeal;
-        } else if(tmp == "gray") {
-            color = Color::gray;
-        } else if(tmp == "darkGray") {
-            color = Color::darkGray;
-        } else if(tmp == "lightGray") {
-            color = Color::lightGray;
-        } else if(tmp == "orange") {
-            color = Color::orange;
-        } else {
-            in.seekg(-tmp.length(), std::ios_base::cur);
-        }
-    }
-    return in;
-}
+std::ostream& operator<<(std::ostream& out, const Color& color);
+std::istream& operator>>(std::istream& in, Color& color);
 
 #endif


### PR DESCRIPTION
Move definition from .h to .cpp to speed up compile time. (color.h) is included in almost all translation units and this inline functions have to be parsed (compiled as weak symbol ?) every time.