### PR TITLE
Use float literals where applicable, fix -Wdouble-promotion

### DIFF
--- a/src/client/animatedtext.cpp
+++ b/src/client/animatedtext.cpp
@@ -53,7 +53,7 @@ void AnimatedText::drawText(const Point& dest, const Rect& visibleRect)
 
     if(visibleRect.contains(rect)) {
         //TODO: cache into a framebuffer
-        float t0 = tf / 1.2;
+        float t0 = tf / 1.2f;
         if(t > t0) {
             Color color = m_color;
             color.setAlpha((float)(1 - (t - t0) / (tf - t0)));
@@ -92,7 +92,7 @@ bool AnimatedText::merge(const AnimatedTextPtr& other)
     if(other->getCachedText().getFont() != m_cachedText.getFont())
         return false;
 
-    if(m_animationTimer.ticksElapsed() > Otc::ANIMATED_TEXT_DURATION / 2.5)
+    if(m_animationTimer.ticksElapsed() > Otc::ANIMATED_TEXT_DURATION / 2.5f)
         return false;
 
     try {

--- a/src/client/map.cpp
+++ b/src/client/map.cpp
@@ -134,7 +134,7 @@ void Map::addThing(const ThingPtr& thing, const Position& pos, int stackPos)
                 if(prevAnimatedText) {
                     Point offset = prevAnimatedText->getOffset();
                     float t = prevAnimatedText->getTimer().ticksElapsed();
-                    if(t < Otc::ANIMATED_TEXT_DURATION / 4.0) { // didnt move 12 pixels
+                    if(t < Otc::ANIMATED_TEXT_DURATION / 4.f) { // didnt move 12 pixels
                         int y = 12 - 48 * t / (float)Otc::ANIMATED_TEXT_DURATION;
                         offset += Point(0, y);
                     }

--- a/src/client/outfit.cpp
+++ b/src/client/outfit.cpp
@@ -37,38 +37,38 @@ Color Outfit::getColor(int color)
 
     float loc1 = 0, loc2 = 0, loc3 = 0;
     if(color % HSI_H_STEPS != 0) {
-        loc1 = color % HSI_H_STEPS * 1.0/18.0;
+        loc1 = color % HSI_H_STEPS * 1.f/18.f;
         loc2 = 1;
         loc3 = 1;
 
         switch(int(color / HSI_H_STEPS)) {
         case 0:
-            loc2 = 0.25;
-            loc3 = 1.00;
+            loc2 = 0.25f;
+            loc3 = 1.f;
             break;
         case 1:
-            loc2 = 0.25;
-            loc3 = 0.75;
+            loc2 = 0.25f;
+            loc3 = 0.75f;
             break;
         case 2:
-            loc2 = 0.50;
-            loc3 = 0.75;
+            loc2 = 0.5f;
+            loc3 = 0.75f;
             break;
         case 3:
-            loc2 = 0.667;
-            loc3 = 0.75;
+            loc2 = 0.667f;
+            loc3 = 0.75f;
             break;
         case 4:
-            loc2 = 1.00;
-            loc3 = 1.00;
+            loc2 = 1.f;
+            loc3 = 1.f;
             break;
         case 5:
-            loc2 = 1.00;
-            loc3 = 0.75;
+            loc2 = 1.f;
+            loc3 = 0.75f;
             break;
         case 6:
-            loc2 = 1.00;
-            loc3 = 0.50;
+            loc2 = 1.f;
+            loc3 = 0.5f;
             break;
         }
     }
@@ -88,27 +88,27 @@ Color Outfit::getColor(int color)
 
     float red = 0, green = 0, blue = 0;
 
-    if(loc1 < 1.0/6.0) {
+    if(loc1 < 1.f/6.f) {
         red = loc3;
         blue = loc3 * (1 - loc2);
         green = blue + (loc3 - blue) * 6 * loc1;
     }
-    else if(loc1 < 2.0/6.0) {
+    else if(loc1 < 2.f/6.f) {
         green = loc3;
         blue = loc3 * (1 - loc2);
         red = green - (loc3 - blue) * (6 * loc1 - 1);
     }
-    else if(loc1 < 3.0/6.0) {
+    else if(loc1 < 3.f/6.f) {
         green = loc3;
         red = loc3 * (1 - loc2);
         blue = red + (loc3 - red) * (6 * loc1 - 2);
     }
-    else if(loc1 < 4.0/6.0) {
+    else if(loc1 < 4.f/6.f) {
         blue = loc3;
         red = loc3 * (1 - loc2);
         green = blue - (loc3 - red) * (6 * loc1 - 3);
     }
-    else if(loc1 < 5.0/6.0) {
+    else if(loc1 < 5.f/6.f) {
         blue = loc3;
         green = loc3 * (1 - loc2);
         red = green + (loc3 - green) * (6 * loc1 - 4);

--- a/src/client/position.h
+++ b/src/client/position.h
@@ -131,7 +131,7 @@ public:
         return positions;
     }
 
-    static double getAngleFromPositions(const Position& fromPos, const Position& toPos) {
+    static float getAngleFromPositions(const Position& fromPos, const Position& toPos) {
         // Returns angle in radians from 0 to 2Pi. -1 means positions are equal.
         int dx = toPos.x - fromPos.x;
         int dy = toPos.y - fromPos.y;
@@ -145,7 +145,7 @@ public:
         return angle;
     }
 
-    double getAngleFromPosition(const Position& position) const {
+    float getAngleFromPosition(const Position& position) const {
         return getAngleFromPositions(*this, position);
     }
 

--- a/src/client/uiprogressrect.cpp
+++ b/src/client/uiprogressrect.cpp
@@ -43,36 +43,36 @@ void UIProgressRect::drawSelf(Fw::DrawPane drawPane)
 
     // 0% - 12.5% (12.5)
     // triangle from top center, to top right (var x)
-    if(m_percent < 12.5) {
-        Point var = Point(std::max<int>(m_percent - 0.0, 0.0) * (drawRect.right() - drawRect.horizontalCenter()) / 12.5, 0);
+    if(m_percent < 12.5f) {
+        Point var = Point(std::max<int>(m_percent - 0.f, 0.f) * (drawRect.right() - drawRect.horizontalCenter()) / 12.5f, 0);
         g_painter->drawFilledTriangle(drawRect.center(), drawRect.topRight() + Point(1,0), drawRect.topCenter() + var);
     }
 
     // 12.5% - 37.5% (25)
     // triangle from top right to bottom right (var y)
-    if(m_percent < 37.5) {
-        Point var = Point(0, std::max<int>(m_percent - 12.5, 0.0) * (drawRect.bottom() - drawRect.top()) / 25.0);
+    if(m_percent < 37.5f) {
+        Point var = Point(0, std::max<int>(m_percent - 12.5f, 0.f) * (drawRect.bottom() - drawRect.top()) / 25.f);
         g_painter->drawFilledTriangle(drawRect.center(), drawRect.bottomRight() + Point(1,1), drawRect.topRight() + var + Point(1,0));
     }
 
     // 37.5% - 62.5% (25)
     // triangle from bottom right to bottom left (var x)
-    if(m_percent < 62.5) {
-        Point var = Point(std::max<int>(m_percent - 37.5, 0.0) * (drawRect.right() - drawRect.left()) / 25.0, 0);
+    if(m_percent < 62.5f) {
+        Point var = Point(std::max<int>(m_percent - 37.5f, 0.f) * (drawRect.right() - drawRect.left()) / 25.f, 0);
         g_painter->drawFilledTriangle(drawRect.center(), drawRect.bottomLeft() + Point(0,1), drawRect.bottomRight() - var + Point(1,1));
     }
 
     // 62.5% - 87.5% (25)
     // triangle from bottom left to top left
-    if(m_percent < 87.5) {
-        Point var = Point(0, std::max<int>(m_percent - 62.5, 0.0) * (drawRect.bottom() - drawRect.top()) / 25.0);
+    if(m_percent < 87.5f) {
+        Point var = Point(0, std::max<int>(m_percent - 62.5f, 0.f) * (drawRect.bottom() - drawRect.top()) / 25.f);
         g_painter->drawFilledTriangle(drawRect.center(), drawRect.topLeft(), drawRect.bottomLeft() - var + Point(0,1));
     }
 
     // 87.5% - 100% (12.5)
     // triangle from top left to top center
     if(m_percent < 100) {
-        Point var = Point(std::max<int>(m_percent - 87.5, 0.0) * (drawRect.horizontalCenter() - drawRect.left()) / 12.5, 0);
+        Point var = Point(std::max<int>(m_percent - 87.5f, 0.f) * (drawRect.horizontalCenter() - drawRect.left()) / 12.5f, 0);
         g_painter->drawFilledTriangle(drawRect.center(), drawRect.topCenter(), drawRect.topLeft() + var);
     }
 
@@ -84,7 +84,7 @@ void UIProgressRect::drawSelf(Fw::DrawPane drawPane)
 
 void UIProgressRect::setPercent(float percent)
 {
-    m_percent = stdext::clamp<float>((double)percent, 0.0, 100.0);
+    m_percent = stdext::clamp<float>(percent, 0.f, 100.f);
 }
 
 void UIProgressRect::onStyleApply(const std::string& styleName, const OTMLNodePtr& styleNode)

--- a/src/framework/ui/uiwidget.cpp
+++ b/src/framework/ui/uiwidget.cpp
@@ -65,7 +65,7 @@ void UIWidget::draw(const Rect& visibleRect, Fw::DrawPane drawPane)
 
     if(m_rotation != 0.0f) {
         g_painter->pushTransformMatrix();
-        g_painter->rotate(m_rect.center(), m_rotation * (Fw::pi / 180.0));
+        g_painter->rotate(m_rect.center(), m_rotation * (Fw::pi / 180.f));
     }
 
     drawSelf(drawPane);


### PR DESCRIPTION
Use float literals to perform more calculation in float instead of performing implicit conversion to double and back to float.

This fixes warnings with -Wdouble-promotion