### PR TITLE
Update Effects.cpp for consistent behavior when rendering special patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 *.sln.docstates
 .idea/
 .vscode/
+.vs
 
 # Build results
 

--- a/src/client/creature.cpp
+++ b/src/client/creature.cpp
@@ -322,6 +322,32 @@ void Creature::drawInformation(const Point& point, bool useGray, const Rect& par
     }
 }
 
+// Get the player outfit texture
+TexturePtr Creature::getOutfitTexture() 
+{
+    int exactSize;
+    if (m_outfit.getCategory() == ThingCategoryCreature)
+        exactSize = getExactSize();
+    else
+        exactSize = g_things.rawGetThingType(m_outfit.getAuxId(), m_outfit.getCategory())->getExactSize();
+
+    int frameSize;
+    frameSize = std::max<int>(exactSize * 0.75f, 2 * Otc::TILE_PIXELS * 0.75f); // Define the frame size
+
+    if (g_graphics.canUseFBO()) {
+        // Create a temporary frame buffer
+        const FrameBufferPtr& outfitBuffer = g_framebuffers.getTemporaryFrameBuffer();
+        outfitBuffer->resize(Size(frameSize, frameSize)); // Set the frame buffer size to frameSize (square)
+        outfitBuffer->bind(); // Draw operations are binded to this framebuffer from now
+        g_painter->setAlphaWriting(true);
+        g_painter->clear(Color::alpha);
+        internalDrawOutfit(Point(frameSize - Otc::TILE_PIXELS, frameSize - Otc::TILE_PIXELS) + getDisplacement(), 1, false, true, getDirection()); // Call the internal outfit draw
+        outfitBuffer->release(); // Release the frame buffer, it's not receiving next draw calls
+        return outfitBuffer->getTexture(); // Return the resulting texture
+    }
+    return nullptr;
+}
+
 void Creature::turn(Otc::Direction direction)
 {
     // if is not walking change the direction right away

--- a/src/client/creature.h
+++ b/src/client/creature.h
@@ -49,6 +49,7 @@ public:
     void internalDrawOutfit(Point dest, float scaleFactor, bool animateWalk, bool animateIdle, Otc::Direction direction, LightView *lightView = nullptr);
     void drawOutfit(const Rect& destRect, bool resize);
     void drawInformation(const Point& point, bool useGray, const Rect& parentRect, int drawFlags);
+    TexturePtr getOutfitTexture(); // Method for receiving the player outfit texture
 
     void setId(uint32 id) { m_id = id; }
     void setName(const std::string& name);

--- a/src/client/effect.cpp
+++ b/src/client/effect.cpp
@@ -46,13 +46,11 @@ void Effect::drawEffect(const Point& dest, float scaleFactor, bool animate, int 
         }
     }
 
-    int xPattern = offsetX % getNumPatternX();
-    if(xPattern < 0)
-        xPattern += getNumPatternX();
+    int xPattern = unsigned(offsetX) % getNumPatternX();
+    xPattern = 1 - xPattern - getNumPatternX();
+    if (xPattern < 0) xPattern += getNumPatternX();
 
-    int yPattern = offsetY % getNumPatternY();
-    if(yPattern < 0)
-        yPattern += getNumPatternY();
+    int yPattern = unsigned(offsetY) % getNumPatternY();
 
     rawGetThingType()->draw(dest, scaleFactor, 0, xPattern, yPattern, 0, animationPhase, lightView);
 }

--- a/src/client/mapview.cpp
+++ b/src/client/mapview.cpp
@@ -37,6 +37,7 @@
 #include <framework/core/eventdispatcher.h>
 #include <framework/core/application.h>
 #include <framework/core/resourcemanager.h>
+#include "game.h"
 
 
 enum {
@@ -186,6 +187,7 @@ void MapView::draw(const Rect& rect)
         m_shader->setUniformValue(ShaderManager::MAP_CENTER_COORD, center.x / (float)framebufferRect.width(), 1.0f - center.y / (float)framebufferRect.height());
         m_shader->setUniformValue(ShaderManager::MAP_GLOBAL_COORD, globalCoord.x / (float)framebufferRect.height(), globalCoord.y / (float)framebufferRect.height());
         m_shader->setUniformValue(ShaderManager::MAP_ZOOM, scaleFactor);
+        m_shader->setUniformValue(ShaderManager::PLAYER_DIRECTION, g_game.getLocalPlayer()->getDirection()); // Set the player direction uniform
         g_painter->setShaderProgram(m_shader);
     }
 

--- a/src/client/shadermanager.cpp
+++ b/src/client/shadermanager.cpp
@@ -134,6 +134,7 @@ void ShaderManager::setupMapShader(const PainterShaderProgramPtr& shader)
     shader->bindUniformLocation(MAP_CENTER_COORD, "u_MapCenterCoord");
     shader->bindUniformLocation(MAP_GLOBAL_COORD, "u_MapGlobalCoord");
     shader->bindUniformLocation(MAP_ZOOM, "u_MapZoom");
+    shader->bindUniformLocation(PLAYER_DIRECTION, "u_PlayerLookDirection"); // Binding player look direction uniform to the shader manager
 }
 
 PainterShaderProgramPtr ShaderManager::getShader(const std::string& name)

--- a/src/client/shadermanager.h
+++ b/src/client/shadermanager.h
@@ -34,7 +34,8 @@ public:
         ITEM_ID_UNIFORM = 10,
         MAP_CENTER_COORD = 10,
         MAP_GLOBAL_COORD = 11,
-        MAP_ZOOM = 12
+        MAP_ZOOM = 12,
+        PLAYER_DIRECTION = 13, // Added player direction to the list of default shader uniforms
     };
 
     void init();

--- a/src/framework/graphics/paintershaderprogram.cpp
+++ b/src/framework/graphics/paintershaderprogram.cpp
@@ -27,6 +27,7 @@
 #include "graphics.h"
 #include <framework/core/clock.h>
 #include <framework/platform/platformwindow.h>
+#include <client/game.h>
 
 PainterShaderProgram::PainterShaderProgram()
 {
@@ -161,6 +162,30 @@ void PainterShaderProgram::addMultiTexture(const std::string& file)
     texture->setRepeat(true);
 
     m_multiTextures.push_back(texture);
+}
+
+// Add player outfit texture to the shader uniforms
+void PainterShaderProgram::addPlayerOutfitMultiTexture()
+{
+    if (m_multiTextures.size() > 3)
+        g_logger.error("cannot add more multi textures to shader, the max is 3");
+
+    TexturePtr texture = g_game.getLocalPlayer()->getOutfitTexture(); // Get player outfit texture
+    if (!texture)
+        return;
+
+    texture->setSmooth(false);
+    texture->setRepeat(false);
+
+    if (m_playerOutfitIndex == INT_MAX)
+    {
+        m_playerOutfitIndex = m_multiTextures.size();
+        m_multiTextures.push_back(texture);
+        return;
+    }
+    else {
+        m_multiTextures.at(m_playerOutfitIndex) = texture;
+    }
 }
 
 void PainterShaderProgram::bindMultiTextures()

--- a/src/framework/graphics/paintershaderprogram.h
+++ b/src/framework/graphics/paintershaderprogram.h
@@ -64,6 +64,7 @@ public:
     void updateTime();
 
     void addMultiTexture(const std::string& file);
+    void addPlayerOutfitMultiTexture();
     void bindMultiTextures();
 
 private:
@@ -76,7 +77,8 @@ private:
     Matrix3 m_textureMatrix;
     Size m_resolution;
     float m_time;
-    std::vector<TexturePtr> m_multiTextures;
+    int m_playerOutfitIndex = INT_MAX;
+    std::vector<TexturePtr> m_multiTextures; // Control variables (a shader should have only one player outfit uniform, yet, it needs to be updated very often)
 };
 
 #endif

--- a/src/framework/luafunctions.cpp
+++ b/src/framework/luafunctions.cpp
@@ -736,6 +736,7 @@ void Application::registerLuaFunctions()
     g_lua.registerClass<ShaderProgram>();
     g_lua.registerClass<PainterShaderProgram>();
     g_lua.bindClassMemberFunction<PainterShaderProgram>("addMultiTexture", &PainterShaderProgram::addMultiTexture);
+    g_lua.bindClassMemberFunction<PainterShaderProgram>("addPlayerOutfitMultiTexture", &PainterShaderProgram::addPlayerOutfitMultiTexture); // Expose addPlayerOutfitMultiTexture to lua api
 
     // ParticleEffect
     g_lua.registerClass<ParticleEffectType>();

--- a/vc14/otclient.sln
+++ b/vc14/otclient.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34723.18
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "otclient", "otclient.vcxproj", "{17A8F78F-1FFB-4128-A3B3-59CC6C19D89A}"
 EndProject

--- a/vc14/otclient.vcxproj
+++ b/vc14/otclient.vcxproj
@@ -28,22 +28,22 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/vc14/settings.props
+++ b/vc14/settings.props
@@ -41,7 +41,7 @@
     <OTCLIENT_LIBDEPS_D>
         glew32d.lib;
         zlibd.lib;
-        zstdd.lib;
+        zstd.lib;
         physfs.lib;
         openal32.lib;
         lua51.lib;


### PR DESCRIPTION
The current rendering behavior of spell effects with patternX = 2 and patternY = 2 exhibits inconsistency, as demonstrated in the provided video:

https://github.com/edubart/otclient/assets/68310301/7160e498-f1a5-43da-9047-6e09b07e37e5

As an example, I've modified the "Eternal Winter" spell area to the following:

```
local area = {
	{0, 0, 0, 1, 0, 0, 0},
	{0, 0, 1, 1, 1, 0, 0},
	{0, 1, 1, 1, 1, 1, 0},
	{1, 1, 1, 2, 1, 1, 1},
	{0, 1, 1, 1, 1, 1, 0},
	{0, 0, 1, 1, 1, 0, 0},
	{0, 0, 0, 1, 0, 0, 0},
}
```

The spell pattern rendering is incompatible with the designated combat area. This pull request aims to rectify the issue by adjusting the effect rendering pattern formula to consistently align with the desired combat area, regardless of the pattern the object possesses.