### PR TITLE
 Make outputMessage::addRawString available in Lua

### DIFF
--- a/src/framework/luafunctions.cpp
+++ b/src/framework/luafunctions.cpp
@@ -818,6 +818,7 @@ void Application::registerLuaFunctions()
     g_lua.bindClassMemberFunction<OutputMessage>("addU32", &OutputMessage::addU32);
     g_lua.bindClassMemberFunction<OutputMessage>("addU64", &OutputMessage::addU64);
     g_lua.bindClassMemberFunction<OutputMessage>("addString", &OutputMessage::addString);
+    g_lua.bindClassMemberFunction<OutputMessage>("addRawString", &OutputMessage::addRawString);
     g_lua.bindClassMemberFunction<OutputMessage>("addPaddingBytes", &OutputMessage::addPaddingBytes);
     g_lua.bindClassMemberFunction<OutputMessage>("encryptRsa", &OutputMessage::encryptRsa);
     g_lua.bindClassMemberFunction<OutputMessage>("getMessageSize", &OutputMessage::getMessageSize);

--- a/src/framework/net/outputmessage.cpp
+++ b/src/framework/net/outputmessage.cpp
@@ -89,6 +89,17 @@ void OutputMessage::addString(const std::string& buffer)
     m_messageSize += len;
 }
 
+void OutputMessage::addRawString(const std::string& buffer)
+{
+    int len = buffer.length();
+    if (len > MAX_STRING_LENGTH)
+        throw stdext::exception(stdext::format("string length > %d", MAX_STRING_LENGTH));
+    checkWrite(len);
+    memcpy((char*)(m_buffer + m_writePos), buffer.c_str(), len);
+    m_writePos += len;
+    m_messageSize += len;
+}
+
 void OutputMessage::addPaddingBytes(int bytes, uint8 byte)
 {
     if(bytes <= 0)

--- a/src/framework/net/outputmessage.h
+++ b/src/framework/net/outputmessage.h
@@ -48,6 +48,7 @@ public:
     void addU32(uint32 value);
     void addU64(uint64 value);
     void addString(const std::string& buffer);
+    void addRawString(const std::string& buffer);
     void addPaddingBytes(int bytes, uint8 byte = 0);
 
     void encryptRsa();


### PR DESCRIPTION
Why write
```lua
msg:addU8(1);
msg:addU8(0);
msg:addU8(113);
```
when you can instead write
```lua
msg:addRawString("\x01\x00\x71");
```
? Would make some lua scripts much easier to write :)